### PR TITLE
feat: 하이라이트 렌더링 (#6)

### DIFF
--- a/src/components/Editor/EditorContainer.tsx
+++ b/src/components/Editor/EditorContainer.tsx
@@ -1,5 +1,7 @@
 import { useRef } from "react";
 
+import type { Sentence } from "@/types/sentence";
+
 import EditorTextarea from "./EditorTextarea";
 import HighlightOverlay from "./HighlightOverlay";
 
@@ -8,9 +10,18 @@ interface EditorContainerProps {
   onTextChange: (text: string) => void;
   placeholder: string;
   disabled?: boolean;
+  sentences: Sentence[];
+  onHighlightClick: (id: string) => void;
 }
 
-const EditorContainer = ({ text, onTextChange, placeholder, disabled }: EditorContainerProps) => {
+const EditorContainer = ({
+  text,
+  onTextChange,
+  placeholder,
+  disabled,
+  sentences,
+  onHighlightClick,
+}: EditorContainerProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -21,8 +32,21 @@ const EditorContainer = ({ text, onTextChange, placeholder, disabled }: EditorCo
   };
 
   return (
-    <div className="relative flex-1 w-full min-h-[500px] rounded-lg border-2 border-dashed border-muted/50 bg-card/50 shadow-sm transition-all duration-200 focus-within:border-primary/30 focus-within:shadow-md">
-      <HighlightOverlay ref={overlayRef}>{text}</HighlightOverlay>
+    <div
+      className={`
+        relative flex-1 w-full min-h-[500px]
+        rounded-lg border-2 border-dashed border-muted/50
+        bg-card/50 shadow-sm
+        transition-all duration-200
+        focus-within:border-primary/30 focus-within:shadow-md
+      `}
+    >
+      <HighlightOverlay
+        ref={overlayRef}
+        text={text}
+        sentences={sentences}
+        onHighlightClick={onHighlightClick}
+      />
       <EditorTextarea
         ref={textareaRef}
         value={text}

--- a/src/components/Editor/EditorSection.tsx
+++ b/src/components/Editor/EditorSection.tsx
@@ -1,20 +1,37 @@
 import { useState } from "react";
 
-import { Loader2, Search, Sparkles } from "lucide-react";
+import { FileText, Loader2, Search, Sparkles } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+// TODO(REMOVE): API 연동 후 삭제 - 목 데이터 import
+import { mockEditorText, mockSentences } from "@/mocks/sentences";
+import type { Sentence } from "@/types/sentence";
 
 import EditorContainer from "./EditorContainer";
 
 const EditorSection = () => {
   const [text, setText] = useState<string>("");
+  const [sentences, setSentences] = useState<Sentence[]>([]);
   const [isChecking, setIsChecking] = useState<boolean>(false);
+
+  // TODO(REMOVE): API 연동 후 삭제 - 샘플 버튼 핸들러
+  const handleSample = () => {
+    setText(mockEditorText);
+    setSentences([]);
+  };
 
   const handleCheck = () => {
     setIsChecking(true);
     // TODO(FE-14): POST /factcheck API 연동
-    // - API 응답 후 setIsChecking(false) 호출
-    // - 응답으로 받은 sentences 기반 하이라이팅 (FE-04)
+    setTimeout(() => {
+      setSentences(mockSentences);
+      setIsChecking(false);
+    }, 1000);
+  };
+
+  const handleHighlightClick = (sentenceId: string) => {
+    console.log("Clicked sentence:", sentenceId);
+    // TODO(FE-06): 결과 패널 카드 활성화
   };
 
   return (
@@ -33,6 +50,11 @@ const EditorSection = () => {
           )}
         </div>
         <div className="flex items-center gap-2">
+          {/* TODO(REMOVE): API 연동 후 삭제 - 샘플 버튼 */}
+          <Button variant="outline" size="sm" className="gap-1.5" onClick={handleSample}>
+            <FileText className="size-4" />
+            샘플
+          </Button>
           <Button
             size="sm"
             className="gap-1.5"
@@ -56,6 +78,8 @@ const EditorSection = () => {
           onTextChange={setText}
           placeholder="팩트체크할 텍스트를 입력하거나 붙여넣기 하세요..."
           disabled={isChecking}
+          sentences={sentences}
+          onHighlightClick={handleHighlightClick}
         />
       </div>
     </div>

--- a/src/components/Editor/EditorTextarea.tsx
+++ b/src/components/Editor/EditorTextarea.tsx
@@ -21,7 +21,7 @@ const EditorTextarea = ({
     <textarea
       ref={ref}
       className={`
-        editor-layer
+        editor-layer z-0
         bg-transparent resize-none border-none outline-none
         caret-foreground placeholder:text-muted-foreground/60
         disabled:cursor-not-allowed disabled:opacity-60

--- a/src/components/Editor/HighlightOverlay.tsx
+++ b/src/components/Editor/HighlightOverlay.tsx
@@ -1,7 +1,7 @@
 import type { Ref } from "react";
 
 import type { Sentence } from "@/types/sentence";
-import { calculatePositions } from "@/utils/calculatePositions";
+import { calculateIndices } from "@/utils/calculateIndices";
 import { createHighlightSegments } from "@/utils/createHighlightSegments";
 
 import HighlightSpan from "./HighlightSpan";
@@ -14,8 +14,8 @@ interface HighlightOverlayProps {
 }
 
 const HighlightOverlay = ({ text, sentences, onHighlightClick, ref }: HighlightOverlayProps) => {
-  const sentencesWithPosition = calculatePositions(text, sentences);
-  const segments = createHighlightSegments(text, sentencesWithPosition);
+  const sentencesWithIndices = calculateIndices(text, sentences);
+  const segments = createHighlightSegments(text, sentencesWithIndices);
 
   return (
     <div ref={ref} className="editor-layer pointer-events-none text-transparent z-10">
@@ -23,11 +23,7 @@ const HighlightOverlay = ({ text, sentences, onHighlightClick, ref }: HighlightO
         segment.type === "plain" ? (
           <span key={segment.key}>{segment.content}</span>
         ) : (
-          <HighlightSpan
-            key={segment.key}
-            sentence={segment.sentence!}
-            onClick={onHighlightClick}
-          />
+          <HighlightSpan key={segment.key} sentence={segment.sentence} onClick={onHighlightClick} />
         ),
       )}
     </div>

--- a/src/components/Editor/HighlightOverlay.tsx
+++ b/src/components/Editor/HighlightOverlay.tsx
@@ -1,20 +1,35 @@
-import type { ReactNode, Ref } from "react";
+import type { Ref } from "react";
+
+import type { Sentence } from "@/types/sentence";
+import { calculatePositions } from "@/utils/calculatePositions";
+import { createHighlightSegments } from "@/utils/createHighlightSegments";
+
+import HighlightSpan from "./HighlightSpan";
 
 interface HighlightOverlayProps {
-  children: ReactNode;
+  text: string;
+  sentences: Sentence[];
+  onHighlightClick: (id: string) => void;
   ref: Ref<HTMLDivElement>;
 }
 
-const HighlightOverlay = ({ children, ref }: HighlightOverlayProps) => {
+const HighlightOverlay = ({ text, sentences, onHighlightClick, ref }: HighlightOverlayProps) => {
+  const sentencesWithPosition = calculatePositions(text, sentences);
+  const segments = createHighlightSegments(text, sentencesWithPosition);
+
   return (
-    <div
-      ref={ref}
-      className={`
-        editor-layer
-        pointer-events-none text-transparent
-      `}
-    >
-      {children}
+    <div ref={ref} className="editor-layer pointer-events-none text-transparent">
+      {segments.map((segment) =>
+        segment.type === "plain" ? (
+          <span key={segment.key}>{segment.content}</span>
+        ) : (
+          <HighlightSpan
+            key={segment.key}
+            sentence={segment.sentence!}
+            onClick={onHighlightClick}
+          />
+        ),
+      )}
     </div>
   );
 };

--- a/src/components/Editor/HighlightOverlay.tsx
+++ b/src/components/Editor/HighlightOverlay.tsx
@@ -18,7 +18,7 @@ const HighlightOverlay = ({ text, sentences, onHighlightClick, ref }: HighlightO
   const segments = createHighlightSegments(text, sentencesWithPosition);
 
   return (
-    <div ref={ref} className="editor-layer pointer-events-none text-transparent">
+    <div ref={ref} className="editor-layer pointer-events-none text-transparent z-10">
       {segments.map((segment) =>
         segment.type === "plain" ? (
           <span key={segment.key}>{segment.content}</span>

--- a/src/components/Editor/HighlightSpan.tsx
+++ b/src/components/Editor/HighlightSpan.tsx
@@ -1,4 +1,4 @@
-import type { SentenceWithPosition } from "@/types/sentence";
+import type { SentenceWithIndices } from "@/types/sentence";
 import { isClaim } from "@/types/sentence";
 
 const HIGHLIGHT_CLASS = {
@@ -8,7 +8,7 @@ const HIGHLIGHT_CLASS = {
 } as const;
 
 interface HighlightSpanProps {
-  sentence: SentenceWithPosition;
+  sentence: SentenceWithIndices;
   onClick: (id: string) => void;
 }
 

--- a/src/components/Editor/HighlightSpan.tsx
+++ b/src/components/Editor/HighlightSpan.tsx
@@ -1,0 +1,25 @@
+import type { SentenceWithPosition } from "@/types/sentence";
+import { isClaim } from "@/types/sentence";
+
+const HIGHLIGHT_CLASS = {
+  TRUE: "highlight-true",
+  FALSE: "highlight-false",
+  opinion: "highlight-opinion",
+} as const;
+
+interface HighlightSpanProps {
+  sentence: SentenceWithPosition;
+  onClick: (id: string) => void;
+}
+
+const HighlightSpan = ({ sentence, onClick }: HighlightSpanProps) => {
+  const className = isClaim(sentence) ? HIGHLIGHT_CLASS[sentence.verdict] : HIGHLIGHT_CLASS.opinion;
+
+  return (
+    <span className={className} onClick={() => onClick(sentence.id)}>
+      {sentence.text}
+    </span>
+  );
+};
+
+export default HighlightSpan;

--- a/src/index.css
+++ b/src/index.css
@@ -50,6 +50,17 @@
 }
 
 :root {
+  /* Verdict Colors (OKLCH) */
+  --verdict-true: oklch(0.792 0.209 151.711);
+  --verdict-true-bg: oklch(0.792 0.209 151.711 / 15%);
+  --verdict-true-bg-hover: oklch(0.792 0.209 151.711 / 25%);
+  --verdict-false: oklch(0.704 0.191 22.216);
+  --verdict-false-bg: oklch(0.704 0.191 22.216 / 15%);
+  --verdict-false-bg-hover: oklch(0.704 0.191 22.216 / 25%);
+  --verdict-opinion: oklch(0.673 0.182 276.935);
+  --verdict-opinion-bg: oklch(0.673 0.182 276.935 / 15%);
+  --verdict-opinion-bg-hover: oklch(0.673 0.182 276.935 / 25%);
+
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -133,5 +144,37 @@
 @utility editor-layer {
   @apply absolute inset-0 overflow-auto;
   @apply font-editor text-editor leading-editor p-editor tracking-editor;
-  @apply whitespace-pre-wrap wrap-break-word;
+  @apply whitespace-pre-wrap break-words;
+}
+
+/* Highlight styles - 팩트체크 결과 하이라이팅 (그라데이션 배경) */
+@utility highlight-base {
+  @apply py-[0.1em] px-[0.25em];
+  @apply my-0 -mx-[0.1em];
+  @apply rounded cursor-pointer pointer-events-auto;
+  @apply transition-all duration-200;
+}
+
+@utility highlight-true {
+  @apply highlight-base;
+  background: linear-gradient(to bottom, transparent 60%, var(--verdict-true-bg) 60%);
+  &:hover {
+    background: linear-gradient(to bottom, transparent 50%, var(--verdict-true-bg-hover) 50%);
+  }
+}
+
+@utility highlight-false {
+  @apply highlight-base;
+  background: linear-gradient(to bottom, transparent 60%, var(--verdict-false-bg) 60%);
+  &:hover {
+    background: linear-gradient(to bottom, transparent 50%, var(--verdict-false-bg-hover) 50%);
+  }
+}
+
+@utility highlight-opinion {
+  @apply highlight-base;
+  background: linear-gradient(to bottom, transparent 60%, var(--verdict-opinion-bg) 60%);
+  &:hover {
+    background: linear-gradient(to bottom, transparent 50%, var(--verdict-opinion-bg-hover) 50%);
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -144,7 +144,8 @@
 @utility editor-layer {
   @apply absolute inset-0 overflow-auto;
   @apply font-editor text-editor leading-editor p-editor tracking-editor;
-  @apply whitespace-pre-wrap break-words;
+  @apply whitespace-pre-wrap;
+  overflow-wrap: break-word;
 }
 
 /* Highlight styles - 팩트체크 결과 하이라이팅 (그라데이션 배경) */

--- a/src/index.css
+++ b/src/index.css
@@ -149,10 +149,10 @@
 
 /* Highlight styles - 팩트체크 결과 하이라이팅 (그라데이션 배경) */
 @utility highlight-base {
-  @apply py-[0.1em] px-[0.25em];
-  @apply my-0 -mx-[0.1em];
   @apply rounded cursor-pointer pointer-events-auto;
   @apply transition-all duration-200;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 
 @utility highlight-true {

--- a/src/index.css
+++ b/src/index.css
@@ -144,8 +144,7 @@
 @utility editor-layer {
   @apply absolute inset-0 overflow-auto;
   @apply font-editor text-editor leading-editor p-editor tracking-editor;
-  @apply whitespace-pre-wrap;
-  overflow-wrap: break-word;
+  @apply whitespace-pre-wrap wrap-break-word;
 }
 
 /* Highlight styles - 팩트체크 결과 하이라이팅 (그라데이션 배경) */

--- a/src/mocks/sentences.ts
+++ b/src/mocks/sentences.ts
@@ -1,8 +1,19 @@
 import type { Sentence } from "@/types/sentence";
 
-export const mockEditorText = `지구는 평평하다는 주장이 있습니다. 그러나 과학적으로 지구는 타원형의 구체입니다. 이것은 개인적인 생각일 뿐입니다. 물은 100도에서 끓습니다.`;
+export const mockEditorText = `지구는 평평하다는 주장이 있습니다. 그러나 과학적으로 지구는 타원형의 구체입니다. 이것은 개인적인 생각일 뿐입니다. 물은 100도에서 끓습니다.
+
+인공지능이 곧 인류를 지배할 것이라는 우려가 있습니다. 하지만 현재 AI는 범용 인공지능(AGI) 수준에 도달하지 못했습니다. 개인적으로 AI의 발전이 기대됩니다. 첫 번째 컴퓨터 프로그래머는 에이다 러브레이스입니다.
+
+비타민 C는 감기를 예방한다고 알려져 있습니다. 그러나 연구에 따르면 비타민 C는 감기 예방 효과가 미미합니다. 건강은 가장 중요한 자산이라고 생각합니다. 인간의 몸은 약 60%가 수분으로 구성되어 있습니다.
+
+커피를 마시면 키가 안 큰다는 속설이 있습니다. 이는 과학적 근거가 없는 미신입니다. 커피 향은 정말 매력적입니다. 카페인의 반감기는 약 5-6시간입니다.
+
+달에는 공기가 없어서 소리가 전달되지 않습니다. 최초의 달 착륙은 1969년 아폴로 11호에 의해 이루어졌습니다. 우주 탐사는 인류의 가장 위대한 도전입니다. 달의 중력은 지구의 약 1/6입니다.
+
+지구는 평평하다는 주장이 있습니다. 이것은 반복되는 주장입니다. 물은 100도에서 끓습니다. 지구는 평평하다는 주장이 있습니다. 다시 한번 강조하지만, 물은 100도에서 끓습니다.`;
 
 export const mockSentences: Sentence[] = [
+  // 첫 번째 단락 - 지구 관련
   {
     id: "sentence-1",
     type: "claim",
@@ -39,5 +50,227 @@ export const mockSentences: Sentence[] = [
     sources: [{ title: "물리학 교과서", url: "https://example.com/physics" }],
     suggestion: null,
     status: "pending",
+  },
+
+  // 두 번째 단락 - AI 관련
+  {
+    id: "sentence-5",
+    type: "claim",
+    text: "인공지능이 곧 인류를 지배할 것이라는 우려가 있습니다.",
+    position: 4,
+    verdict: "FALSE",
+    sources: [
+      { title: "MIT Technology Review", url: "https://technologyreview.com/ai-safety" },
+      { title: "Nature AI Research", url: "https://nature.com/ai-research" },
+    ],
+    suggestion: "현재 AI 기술은 특정 작업에 특화되어 있으며, 자율적 의사결정 능력이 제한적입니다.",
+    status: "pending",
+  },
+  {
+    id: "sentence-6",
+    type: "claim",
+    text: "현재 AI는 범용 인공지능(AGI) 수준에 도달하지 못했습니다.",
+    position: 5,
+    verdict: "TRUE",
+    sources: [{ title: "OpenAI Research Blog", url: "https://openai.com/research" }],
+    suggestion: null,
+    status: "applied",
+  },
+  {
+    id: "sentence-7",
+    type: "opinion",
+    text: "개인적으로 AI의 발전이 기대됩니다.",
+    position: 6,
+    reason: "개인적 기대감을 표현한 주관적 문장",
+  },
+  {
+    id: "sentence-8",
+    type: "claim",
+    text: "첫 번째 컴퓨터 프로그래머는 에이다 러브레이스입니다.",
+    position: 7,
+    verdict: "TRUE",
+    sources: [
+      { title: "Computer History Museum", url: "https://computerhistory.org/ada-lovelace" },
+    ],
+    suggestion: null,
+    status: "pending",
+  },
+
+  // 세 번째 단락 - 건강/비타민 관련
+  {
+    id: "sentence-9",
+    type: "claim",
+    text: "비타민 C는 감기를 예방한다고 알려져 있습니다.",
+    position: 8,
+    verdict: "FALSE",
+    sources: [
+      { title: "Cochrane Review", url: "https://cochrane.org/vitamin-c-cold" },
+      { title: "Harvard Health", url: "https://health.harvard.edu/cold-prevention" },
+    ],
+    suggestion:
+      "비타민 C는 감기 예방에 뚜렷한 효과가 없으며, 증상 지속 기간을 약간 줄일 수 있습니다.",
+    status: "ignored",
+  },
+  {
+    id: "sentence-10",
+    type: "claim",
+    text: "연구에 따르면 비타민 C는 감기 예방 효과가 미미합니다.",
+    position: 9,
+    verdict: "TRUE",
+    sources: [{ title: "PubMed Central", url: "https://ncbi.nlm.nih.gov/pmc/vitamin-c" }],
+    suggestion: null,
+    status: "pending",
+  },
+  {
+    id: "sentence-11",
+    type: "opinion",
+    text: "건강은 가장 중요한 자산이라고 생각합니다.",
+    position: 10,
+    reason: "가치 판단이 포함된 주관적 의견",
+  },
+  {
+    id: "sentence-12",
+    type: "claim",
+    text: "인간의 몸은 약 60%가 수분으로 구성되어 있습니다.",
+    position: 11,
+    verdict: "TRUE",
+    sources: [{ title: "USGS Water Science", url: "https://usgs.gov/water-science" }],
+    suggestion: null,
+    status: "pending",
+  },
+
+  // 네 번째 단락 - 커피 관련
+  {
+    id: "sentence-13",
+    type: "claim",
+    text: "커피를 마시면 키가 안 큰다는 속설이 있습니다.",
+    position: 12,
+    verdict: "FALSE",
+    sources: [
+      { title: "Harvard Health Publishing", url: "https://health.harvard.edu/coffee-myths" },
+    ],
+    suggestion: "커피 섭취와 성장 저해 사이에는 과학적 연관성이 없습니다.",
+    status: "pending",
+  },
+  {
+    id: "sentence-14",
+    type: "claim",
+    text: "이는 과학적 근거가 없는 미신입니다.",
+    position: 13,
+    verdict: "TRUE",
+    sources: [{ title: "Scientific American", url: "https://scientificamerican.com/coffee" }],
+    suggestion: null,
+    status: "applied",
+  },
+  {
+    id: "sentence-15",
+    type: "opinion",
+    text: "커피 향은 정말 매력적입니다.",
+    position: 14,
+    reason: "개인적 선호도를 표현한 주관적 문장",
+  },
+  {
+    id: "sentence-16",
+    type: "claim",
+    text: "카페인의 반감기는 약 5-6시간입니다.",
+    position: 15,
+    verdict: "TRUE",
+    sources: [
+      { title: "Sleep Foundation", url: "https://sleepfoundation.org/caffeine" },
+      { title: "FDA", url: "https://fda.gov/caffeine-facts" },
+    ],
+    suggestion: null,
+    status: "pending",
+  },
+
+  // 다섯 번째 단락 - 우주 관련
+  {
+    id: "sentence-17",
+    type: "claim",
+    text: "달에는 공기가 없어서 소리가 전달되지 않습니다.",
+    position: 16,
+    verdict: "TRUE",
+    sources: [{ title: "NASA Moon Facts", url: "https://nasa.gov/moon" }],
+    suggestion: null,
+    status: "pending",
+  },
+  {
+    id: "sentence-18",
+    type: "claim",
+    text: "최초의 달 착륙은 1969년 아폴로 11호에 의해 이루어졌습니다.",
+    position: 17,
+    verdict: "TRUE",
+    sources: [
+      { title: "NASA Apollo 11", url: "https://nasa.gov/apollo-11" },
+      { title: "Smithsonian Air and Space", url: "https://airandspace.si.edu/apollo-11" },
+    ],
+    suggestion: null,
+    status: "pending",
+  },
+  {
+    id: "sentence-19",
+    type: "opinion",
+    text: "우주 탐사는 인류의 가장 위대한 도전입니다.",
+    position: 18,
+    reason: "가치 판단이 포함된 주관적 의견",
+  },
+  {
+    id: "sentence-20",
+    type: "claim",
+    text: "달의 중력은 지구의 약 1/6입니다.",
+    position: 19,
+    verdict: "TRUE",
+    sources: [{ title: "NASA Science", url: "https://science.nasa.gov/moon-gravity" }],
+    suggestion: null,
+    status: "pending",
+  },
+
+  // 여섯 번째 단락 - 중복 문장 테스트
+  {
+    id: "sentence-21",
+    type: "claim",
+    text: "지구는 평평하다는 주장이 있습니다.",
+    position: 20,
+    verdict: "FALSE",
+    sources: [{ title: "NASA - Earth", url: "https://nasa.gov/earth" }],
+    suggestion: "지구는 둥글다는 것이 과학적으로 증명되었습니다.",
+    status: "pending",
+  },
+  {
+    id: "sentence-22",
+    type: "opinion",
+    text: "이것은 반복되는 주장입니다.",
+    position: 21,
+    reason: "주관적 표현이 포함된 문장",
+  },
+  {
+    id: "sentence-23",
+    type: "claim",
+    text: "물은 100도에서 끓습니다.",
+    position: 22,
+    verdict: "TRUE",
+    sources: [{ title: "물리학 교과서", url: "https://example.com/physics" }],
+    suggestion: null,
+    status: "pending",
+  },
+  {
+    id: "sentence-24",
+    type: "claim",
+    text: "지구는 평평하다는 주장이 있습니다.",
+    position: 23,
+    verdict: "FALSE",
+    sources: [{ title: "NASA - Earth", url: "https://nasa.gov/earth" }],
+    suggestion: "지구는 둥글다는 것이 과학적으로 증명되었습니다.",
+    status: "applied",
+  },
+  {
+    id: "sentence-25",
+    type: "claim",
+    text: "물은 100도에서 끓습니다.",
+    position: 24,
+    verdict: "TRUE",
+    sources: [{ title: "물리학 교과서", url: "https://example.com/physics" }],
+    suggestion: null,
+    status: "ignored",
   },
 ];

--- a/src/mocks/sentences.ts
+++ b/src/mocks/sentences.ts
@@ -1,0 +1,43 @@
+import type { Sentence } from "@/types/sentence";
+
+export const mockEditorText = `지구는 평평하다는 주장이 있습니다. 그러나 과학적으로 지구는 타원형의 구체입니다. 이것은 개인적인 생각일 뿐입니다. 물은 100도에서 끓습니다.`;
+
+export const mockSentences: Sentence[] = [
+  {
+    id: "sentence-1",
+    type: "claim",
+    text: "지구는 평평하다는 주장이 있습니다.",
+    position: 0,
+    verdict: "FALSE",
+    sources: [{ title: "NASA - Earth", url: "https://nasa.gov/earth" }],
+    suggestion: "지구는 둥글다는 것이 과학적으로 증명되었습니다.",
+    status: "pending",
+  },
+  {
+    id: "sentence-2",
+    type: "claim",
+    text: "지구는 타원형의 구체입니다.",
+    position: 1,
+    verdict: "TRUE",
+    sources: [{ title: "NASA - Earth Facts", url: "https://nasa.gov/earth-facts" }],
+    suggestion: null,
+    status: "pending",
+  },
+  {
+    id: "sentence-3",
+    type: "opinion",
+    text: "이것은 개인적인 생각일 뿐입니다.",
+    position: 2,
+    reason: "주관적 판단이 포함된 문장",
+  },
+  {
+    id: "sentence-4",
+    type: "claim",
+    text: "물은 100도에서 끓습니다.",
+    position: 3,
+    verdict: "TRUE",
+    sources: [{ title: "물리학 교과서", url: "https://example.com/physics" }],
+    suggestion: null,
+    status: "pending",
+  },
+];

--- a/src/types/sentence.ts
+++ b/src/types/sentence.ts
@@ -28,7 +28,7 @@ export interface OpinionSentence extends BaseSentence {
 
 export type Sentence = ClaimSentence | OpinionSentence;
 
-export type SentenceWithPosition = Sentence & {
+export type SentenceWithIndices = Sentence & {
   startIndex: number;
   endIndex: number;
 };

--- a/src/types/sentence.ts
+++ b/src/types/sentence.ts
@@ -1,0 +1,39 @@
+export interface Source {
+  title: string;
+  url: string;
+}
+
+export type Verdict = "TRUE" | "FALSE";
+
+export type ClaimStatus = "pending" | "applied" | "ignored";
+
+interface BaseSentence {
+  id: string;
+  text: string;
+  position: number;
+}
+
+export interface ClaimSentence extends BaseSentence {
+  type: "claim";
+  verdict: Verdict;
+  sources: Source[];
+  status: ClaimStatus;
+  suggestion: string | null;
+}
+
+export interface OpinionSentence extends BaseSentence {
+  type: "opinion";
+  reason: string;
+}
+
+export type Sentence = ClaimSentence | OpinionSentence;
+
+export type SentenceWithPosition = Sentence & {
+  startIndex: number;
+  endIndex: number;
+};
+
+export const isClaim = (sentence: Sentence): sentence is ClaimSentence => sentence.type === "claim";
+
+export const isOpinion = (sentence: Sentence): sentence is OpinionSentence =>
+  sentence.type === "opinion";

--- a/src/utils/calculateIndices.ts
+++ b/src/utils/calculateIndices.ts
@@ -1,4 +1,4 @@
-import type { Sentence, SentenceWithPosition } from "@/types/sentence";
+import type { Sentence, SentenceWithIndices } from "@/types/sentence";
 
 /**
  * sentences 배열의 각 문장에 대해 editorText 내 위치를 계산합니다.
@@ -11,10 +11,10 @@ import type { Sentence, SentenceWithPosition } from "@/types/sentence";
  * - sentences는 반드시 텍스트 내 등장 순서(position)대로 정렬되어야 합니다
  * - 문장을 찾지 못하면 startIndex, endIndex가 -1로 설정됩니다
  */
-export const calculatePositions = (
+export const calculateIndices = (
   editorText: string,
   sentences: Sentence[],
-): SentenceWithPosition[] => {
+): SentenceWithIndices[] => {
   let searchFrom = 0;
 
   return sentences.map((sentence) => {

--- a/src/utils/calculatePositions.ts
+++ b/src/utils/calculatePositions.ts
@@ -1,0 +1,33 @@
+import type { Sentence, SentenceWithPosition } from "@/types/sentence";
+
+/**
+ * sentences 배열의 각 문장에 대해 editorText 내 위치를 계산합니다.
+ *
+ * @param editorText - 전체 에디터 텍스트
+ * @param sentences - 위치를 계산할 문장 배열 (position 순 정렬 필수)
+ * @returns 각 문장에 startIndex, endIndex가 추가된 배열
+ *
+ * @remarks
+ * - sentences는 반드시 텍스트 내 등장 순서(position)대로 정렬되어야 합니다
+ * - 문장을 찾지 못하면 startIndex, endIndex가 -1로 설정됩니다
+ */
+export const calculatePositions = (
+  editorText: string,
+  sentences: Sentence[],
+): SentenceWithPosition[] => {
+  let searchFrom = 0;
+
+  return sentences.map((sentence) => {
+    const startIndex = editorText.indexOf(sentence.text, searchFrom);
+
+    if (startIndex === -1) {
+      return { ...sentence, startIndex: -1, endIndex: -1 };
+    }
+
+    const endIndex = startIndex + sentence.text.length;
+
+    searchFrom = endIndex;
+
+    return { ...sentence, startIndex, endIndex };
+  });
+};

--- a/src/utils/createHighlightSegments.ts
+++ b/src/utils/createHighlightSegments.ts
@@ -1,11 +1,19 @@
-import type { SentenceWithPosition } from "@/types/sentence";
+import type { SentenceWithIndices } from "@/types/sentence";
 
-export interface TextSegment {
-  type: "plain" | "highlight";
+interface PlainSegment {
+  type: "plain";
   content: string;
   key: string;
-  sentence?: SentenceWithPosition;
 }
+
+interface HighlightSegment {
+  type: "highlight";
+  content: string;
+  key: string;
+  sentence: SentenceWithIndices;
+}
+
+export type TextSegment = PlainSegment | HighlightSegment;
 
 const createPlainSegment = (content: string, index: number): TextSegment => ({
   type: "plain",
@@ -13,7 +21,7 @@ const createPlainSegment = (content: string, index: number): TextSegment => ({
   key: `plain-${index}`,
 });
 
-const createHighlightSegment = (sentence: SentenceWithPosition): TextSegment => ({
+const createHighlightSegment = (sentence: SentenceWithIndices): TextSegment => ({
   type: "highlight",
   content: sentence.text,
   key: sentence.id,
@@ -22,7 +30,7 @@ const createHighlightSegment = (sentence: SentenceWithPosition): TextSegment => 
 
 export const createHighlightSegments = (
   text: string,
-  sentences: SentenceWithPosition[],
+  sentences: SentenceWithIndices[],
 ): TextSegment[] => {
   const segments: TextSegment[] = [];
   let cursor = 0;

--- a/src/utils/createHighlightSegments.ts
+++ b/src/utils/createHighlightSegments.ts
@@ -1,0 +1,48 @@
+import type { SentenceWithPosition } from "@/types/sentence";
+
+export interface TextSegment {
+  type: "plain" | "highlight";
+  content: string;
+  key: string;
+  sentence?: SentenceWithPosition;
+}
+
+const createPlainSegment = (content: string, index: number): TextSegment => ({
+  type: "plain",
+  content,
+  key: `plain-${index}`,
+});
+
+const createHighlightSegment = (sentence: SentenceWithPosition): TextSegment => ({
+  type: "highlight",
+  content: sentence.text,
+  key: sentence.id,
+  sentence,
+});
+
+export const createHighlightSegments = (
+  text: string,
+  sentences: SentenceWithPosition[],
+): TextSegment[] => {
+  const segments: TextSegment[] = [];
+  let cursor = 0;
+
+  const validSentences = sentences.filter((s) => s.startIndex !== -1);
+
+  for (const sentence of validSentences) {
+    if (sentence.startIndex > cursor) {
+      const plainText = text.slice(cursor, sentence.startIndex);
+      segments.push(createPlainSegment(plainText, cursor));
+    }
+
+    segments.push(createHighlightSegment(sentence));
+    cursor = sentence.endIndex;
+  }
+
+  if (cursor < text.length) {
+    const remainingText = text.slice(cursor);
+    segments.push(createPlainSegment(remainingText, cursor));
+  }
+
+  return segments;
+};


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)

- Closes #6

## 🛠️ 작업 내용 (Description)

### AS-IS

- HighlightOverlay가 단순 div 래퍼 역할만 수행
- 하이라이트 렌더링 로직 없음
- 목 데이터 및 타입 정의 없음

### TO-BE

- **하이라이트 렌더링 시스템 구현**
- `calculatePositions()`: position 기반 텍스트 위치 계산
- `createHighlightSegments()`: 텍스트 → 세그먼트 분할 (팩토리 패턴)
- `HighlightSpan`: 타입별 색상 + 클릭 이벤트 처리
- **verdict 색상 스타일**
- TRUE: 녹색 (OKLCH)
- FALSE: 빨간색 (OKLCH)
- OPINION: 보라색 (OKLCH)
- **목 데이터 및 타입 정의**
- `Sentence`, `ClaimSentence`, `OpinionSentence` 타입
- 5개 단락 20개 문장 샘플 데이터 (다양한 status 포함)

## 📸 스크린샷 (Screenshots)

|           모바일           |           데스크탑            |
| :------------------------: | :------------------------: |
| <img width="580" height="837" alt="image" src="https://github.com/user-attachments/assets/c47a4234-bc48-445e-bb8a-c9cafb5ded09" /> | <img width="1531" height="807" alt="image" src="https://github.com/user-attachments/assets/3ba11b0b-363a-4ab4-abbf-09c9b9a8405b" /> |

## ✅ 체크리스트 (Self Checklist)

**기본 확인**

- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요?
- [ ] (필요 시) 관련 문서나 API 명세서를 업데이트했나요?

**UI / UX (해당 시)**

- [x] 다양한 화면 크기(모바일/데스크탑)에서 깨짐이 없나요?
- [x] 주요 브라우저에서 동작을 확인했나요?

**안정성 및 배포**

- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요?
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 🧪 테스트 방법 (How to Test)

### 기본 시나리오

1. 로컬 서버 실행 (`pnpm dev`)
2. **샘플** 버튼 클릭 → 5개 단락 텍스트 로드
3. **전체 검사** 버튼 클릭 → 1초 후 하이라이트 표시
4. 색상 확인 (20개 문장):

- **FALSE (빨간색)**: "지구는 평평하다는 주장", "인공지능이 곧 인류를 지배", "비타민 C는 감기를 예방", "커피를 마시면 키가 안 큰다"
- **TRUE (녹색)**: "지구는 타원형의 구체", "물은 100도에서 끓습니다", "달의 중력은 지구의 약 1/6" 등
- **OPINION (보라색)**: "이것은 개인적인 생각", "건강은 가장 중요한 자산", "커피 향은 정말 매력적" 등

5. 하이라이트 클릭 → DevTools Console에서 `Clicked sentence: sentence-X` 확인

### 엣지 케이스

6. **텍스트 수정 후 재계산**: 하이라이트된 상태에서 텍스트 앞에 문자 추가 → 하이라이트 위치 자동 재계산
7. **문장 삭제 시**: 하이라이트된 문장 일부를 삭제 → 해당 하이라이트 사라짐 (startIndex: -1)
8. **빈 sentences**: 텍스트만 있고 sentences 빈 배열 → 일반 텍스트로 렌더링

## ⚠️ 특이사항 (Notes)

### 설계 결정: HighlightOverlay props 변경

**children → text + sentences props로 변경한 이유:**

| 관점      | children 방식                              | props 방식 (채택)                  |
| --------- | ------------------------------------------ | ---------------------------------- |
| 책임      | 부모가 렌더링 로직 담당                    | HighlightOverlay가 하이라이팅 책임 |
| 이름 일치 | "HighlightOverlay"인데 하이라이팅 안 함 ❌ | 이름과 역할 일치 ✅                |
| 재사용성  | 다른 곳에서 쓰려면 로직 복사               | 바로 사용 가능                     |

### 아키텍처 분리

```
EditorSection (상태)
└── EditorContainer (레이아웃)
  ├── HighlightOverlay (하이라이팅)
  │   ├── calculatePositions() → 위치 계산
  │   ├── createHighlightSegments() → 세그먼트 분할
  │   └── HighlightSpan (스타일 + 클릭)
  └── EditorTextarea (입력)
```

### 샘플 버튼 복원

- 이전 PR(FE-03)에서 삭제했던 **샘플 버튼**을 다시 추가
- 목적: 하이라이팅 기능 테스트를 위해 목 데이터를 쉽게 로드하기 위함
- API 연동(FE-14) 후 다시 삭제 예정

### TODO(REMOVE) 표시

- `src/mocks/sentences.ts` - API 연동 후 삭제
- `EditorSection.tsx`의 샘플 버튼 핸들러 - API 연동 후 삭제