### PR TITLE
feat: 결과 패널 및 에디터 연동 구현 (#11)

### DIFF
--- a/src/components/Analyze/AnalyzePanel.tsx
+++ b/src/components/Analyze/AnalyzePanel.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { type Ref, useState } from "react";
 
 import type { Sentence } from "@/types/sentence";
 
 import AnalyzeTabHeader from "./AnalyzeTabHeader";
 import HistoryPanel from "./HistoryPanel";
-import ResultsPanel from "./ResultsPanel";
+import ResultsPanel, { type ResultsPanelHandle } from "./ResultsPanel";
 
 type TabType = "results" | "history";
 
@@ -14,6 +14,7 @@ interface AnalyzePanelProps {
   onIgnore: (id: string) => void;
   activeSentenceId: string | null;
   onCardClick: (id: string) => void;
+  ref: Ref<ResultsPanelHandle>;
 }
 
 const AnalyzePanel = ({
@@ -22,6 +23,7 @@ const AnalyzePanel = ({
   onIgnore,
   activeSentenceId,
   onCardClick,
+  ref,
 }: AnalyzePanelProps) => {
   const [activeTab, setActiveTab] = useState<TabType>("results");
 
@@ -34,6 +36,7 @@ const AnalyzePanel = ({
           <div className="flex min-h-0 flex-1 flex-col">
             {activeTab === "results" ? (
               <ResultsPanel
+                ref={ref}
                 sentences={sentences}
                 onApply={onApply}
                 onIgnore={onIgnore}

--- a/src/components/Analyze/AnalyzePanel.tsx
+++ b/src/components/Analyze/AnalyzePanel.tsx
@@ -2,9 +2,9 @@ import { useState } from "react";
 
 import type { Sentence } from "@/types/sentence";
 
-import { AnalyzeTabHeader } from "./AnalyzeTabHeader";
-import { HistoryPanel } from "./HistoryPanel";
-import { ResultsPanel } from "./ResultsPanel";
+import AnalyzeTabHeader from "./AnalyzeTabHeader";
+import HistoryPanel from "./HistoryPanel";
+import ResultsPanel from "./ResultsPanel";
 
 type TabType = "results" | "history";
 
@@ -14,7 +14,7 @@ interface AnalyzePanelProps {
   onIgnore: (id: string) => void;
 }
 
-export const AnalyzePanel = ({ sentences, onApply, onIgnore }: AnalyzePanelProps) => {
+const AnalyzePanel = ({ sentences, onApply, onIgnore }: AnalyzePanelProps) => {
   const [activeTab, setActiveTab] = useState<TabType>("results");
 
   return (
@@ -35,3 +35,5 @@ export const AnalyzePanel = ({ sentences, onApply, onIgnore }: AnalyzePanelProps
     </div>
   );
 };
+
+export default AnalyzePanel;

--- a/src/components/Analyze/AnalyzePanel.tsx
+++ b/src/components/Analyze/AnalyzePanel.tsx
@@ -12,9 +12,17 @@ interface AnalyzePanelProps {
   sentences: Sentence[];
   onApply: (id: string) => void;
   onIgnore: (id: string) => void;
+  activeSentenceId: string | null;
+  onCardClick: (id: string) => void;
 }
 
-const AnalyzePanel = ({ sentences, onApply, onIgnore }: AnalyzePanelProps) => {
+const AnalyzePanel = ({
+  sentences,
+  onApply,
+  onIgnore,
+  activeSentenceId,
+  onCardClick,
+}: AnalyzePanelProps) => {
   const [activeTab, setActiveTab] = useState<TabType>("results");
 
   return (
@@ -25,7 +33,13 @@ const AnalyzePanel = ({ sentences, onApply, onIgnore }: AnalyzePanelProps) => {
         <div className="flex overflow-y-auto h-full">
           <div className="flex min-h-0 flex-1 flex-col">
             {activeTab === "results" ? (
-              <ResultsPanel sentences={sentences} onApply={onApply} onIgnore={onIgnore} />
+              <ResultsPanel
+                sentences={sentences}
+                onApply={onApply}
+                onIgnore={onIgnore}
+                activeSentenceId={activeSentenceId}
+                onCardClick={onCardClick}
+              />
             ) : (
               <HistoryPanel />
             )}

--- a/src/components/Analyze/AnalyzeTabHeader.tsx
+++ b/src/components/Analyze/AnalyzeTabHeader.tsx
@@ -9,7 +9,7 @@ interface AnalyzeTabHeaderProps {
   onTabChange: (tab: TabType) => void;
 }
 
-export const AnalyzeTabHeader = ({ activeTab, onTabChange }: AnalyzeTabHeaderProps) => {
+const AnalyzeTabHeader = ({ activeTab, onTabChange }: AnalyzeTabHeaderProps) => {
   return (
     <div className="flex h-14 shrink-0 border-b border-border">
       <button
@@ -39,3 +39,5 @@ export const AnalyzeTabHeader = ({ activeTab, onTabChange }: AnalyzeTabHeaderPro
     </div>
   );
 };
+
+export default AnalyzeTabHeader;

--- a/src/components/Analyze/HistoryPanel.tsx
+++ b/src/components/Analyze/HistoryPanel.tsx
@@ -1,6 +1,6 @@
 import { History } from "lucide-react";
 
-export const HistoryPanel = () => {
+const HistoryPanel = () => {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-4">
       <div className="flex size-20 items-center justify-center rounded-full bg-muted">
@@ -13,3 +13,5 @@ export const HistoryPanel = () => {
     </div>
   );
 };
+
+export default HistoryPanel;

--- a/src/components/Analyze/ResultsPanel.tsx
+++ b/src/components/Analyze/ResultsPanel.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from "react";
+
 import {
   CheckCircle2,
   ExternalLink,
@@ -19,6 +21,8 @@ interface ResultsPanelProps {
   sentences: Sentence[];
   onApply: (id: string) => void;
   onIgnore: (id: string) => void;
+  activeSentenceId: string | null;
+  onCardClick: (id: string) => void;
 }
 
 const VERDICT_STYLES = {
@@ -58,7 +62,25 @@ const getClaimStyle = (sentence: ClaimSentence) => {
   return VERDICT_STYLES[sentence.verdict];
 };
 
-const ResultsPanel = ({ sentences, onApply, onIgnore }: ResultsPanelProps) => {
+const ResultsPanel = ({
+  sentences,
+  onApply,
+  onIgnore,
+  activeSentenceId,
+  onCardClick,
+}: ResultsPanelProps) => {
+  const cardRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  // 에디터 하이라이트 클릭 시 해당 카드로 스크롤
+  useEffect(() => {
+    if (activeSentenceId) {
+      const card = cardRefs.current.get(activeSentenceId);
+      if (card) {
+        card.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    }
+  }, [activeSentenceId]);
+
   const stats = {
     true: sentences.filter((s) => isClaim(s) && s.verdict === "TRUE").length,
     false: sentences.filter((s) => isClaim(s) && s.verdict === "FALSE").length,
@@ -122,8 +144,16 @@ const ResultsPanel = ({ sentences, onApply, onIgnore }: ResultsPanelProps) => {
             return (
               <Card
                 key={sentence.id}
+                ref={(el) => {
+                  if (el) cardRefs.current.set(sentence.id, el);
+                  else cardRefs.current.delete(sentence.id);
+                }}
                 variant={style.cardVariant}
-                className="flex flex-col gap-4 transition-all duration-300"
+                className={cn(
+                  "flex flex-col gap-4 transition-all duration-300 cursor-pointer",
+                  activeSentenceId === sentence.id && "ring-2 ring-primary",
+                )}
+                onClick={() => onCardClick(sentence.id)}
               >
                 <div className="flex flex-col gap-3">
                   <div className="flex items-center gap-2">
@@ -198,7 +228,19 @@ const ResultsPanel = ({ sentences, onApply, onIgnore }: ResultsPanelProps) => {
 
           if (isOpinion(sentence)) {
             return (
-              <Card key={sentence.id} variant="opinion" className="flex flex-col gap-4">
+              <Card
+                key={sentence.id}
+                ref={(el) => {
+                  if (el) cardRefs.current.set(sentence.id, el);
+                  else cardRefs.current.delete(sentence.id);
+                }}
+                variant="opinion"
+                className={cn(
+                  "flex flex-col gap-4 cursor-pointer",
+                  activeSentenceId === sentence.id && "ring-2 ring-primary",
+                )}
+                onClick={() => onCardClick(sentence.id)}
+              >
                 <div className="flex items-center gap-2">
                   <MessageSquare className="size-5 text-blue-500" />
                   <span className="rounded-full bg-blue-100 px-2.5 py-0.5 text-sm font-medium text-blue-600">

--- a/src/components/Analyze/ResultsPanel.tsx
+++ b/src/components/Analyze/ResultsPanel.tsx
@@ -58,7 +58,7 @@ const getClaimStyle = (sentence: ClaimSentence) => {
   return VERDICT_STYLES[sentence.verdict];
 };
 
-export const ResultsPanel = ({ sentences, onApply, onIgnore }: ResultsPanelProps) => {
+const ResultsPanel = ({ sentences, onApply, onIgnore }: ResultsPanelProps) => {
   const stats = {
     true: sentences.filter((s) => isClaim(s) && s.verdict === "TRUE").length,
     false: sentences.filter((s) => isClaim(s) && s.verdict === "FALSE").length,
@@ -219,3 +219,5 @@ export const ResultsPanel = ({ sentences, onApply, onIgnore }: ResultsPanelProps
     </div>
   );
 };
+
+export default ResultsPanel;

--- a/src/components/Analyze/ResultsPanel.tsx
+++ b/src/components/Analyze/ResultsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { type Ref, useImperativeHandle, useRef } from "react";
 
 import {
   CheckCircle2,
@@ -17,12 +17,17 @@ import { cn } from "@/lib/utils";
 import type { ClaimSentence, Sentence } from "@/types/sentence";
 import { isClaim, isOpinion } from "@/types/sentence";
 
+export interface ResultsPanelHandle {
+  scrollToCard: (id: string) => void;
+}
+
 interface ResultsPanelProps {
   sentences: Sentence[];
   onApply: (id: string) => void;
   onIgnore: (id: string) => void;
   activeSentenceId: string | null;
   onCardClick: (id: string) => void;
+  ref: Ref<ResultsPanelHandle>;
 }
 
 const VERDICT_STYLES = {
@@ -68,18 +73,18 @@ const ResultsPanel = ({
   onIgnore,
   activeSentenceId,
   onCardClick,
+  ref,
 }: ResultsPanelProps) => {
   const cardRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
-  // 에디터 하이라이트 클릭 시 해당 카드로 스크롤
-  useEffect(() => {
-    if (activeSentenceId) {
-      const card = cardRefs.current.get(activeSentenceId);
+  useImperativeHandle(ref, () => ({
+    scrollToCard: (id: string) => {
+      const card = cardRefs.current.get(id);
       if (card) {
         card.scrollIntoView({ behavior: "smooth", block: "center" });
       }
-    }
-  }, [activeSentenceId]);
+    },
+  }));
 
   const stats = {
     true: sentences.filter((s) => isClaim(s) && s.verdict === "TRUE").length,

--- a/src/components/Editor/EditorContainer.tsx
+++ b/src/components/Editor/EditorContainer.tsx
@@ -28,11 +28,9 @@ const EditorContainer = ({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleScroll = () => {
-    requestAnimationFrame(() => {
-      if (overlayRef.current && textareaRef.current) {
-        overlayRef.current.scrollTop = textareaRef.current.scrollTop;
-      }
-    });
+    if (overlayRef.current && textareaRef.current) {
+      overlayRef.current.scrollTop = textareaRef.current.scrollTop;
+    }
   };
 
   // 오버레이에서 휠 스크롤 시 textarea로 전달

--- a/src/components/Editor/EditorContainer.tsx
+++ b/src/components/Editor/EditorContainer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { type WheelEvent, useEffect, useRef } from "react";
 
 import type { Sentence } from "@/types/sentence";
 
@@ -28,8 +28,18 @@ const EditorContainer = ({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleScroll = () => {
-    if (overlayRef.current && textareaRef.current) {
-      overlayRef.current.scrollTop = textareaRef.current.scrollTop;
+    requestAnimationFrame(() => {
+      if (overlayRef.current && textareaRef.current) {
+        overlayRef.current.scrollTop = textareaRef.current.scrollTop;
+      }
+    });
+  };
+
+  // 오버레이에서 휠 스크롤 시 textarea로 전달
+  const handleWheel = (e: WheelEvent<HTMLDivElement>) => {
+    if (textareaRef.current) {
+      textareaRef.current.scrollTop += e.deltaY;
+      handleScroll(); // 오버레이도 동기화
     }
   };
 
@@ -61,6 +71,8 @@ const EditorContainer = ({
         text={text}
         sentences={sentences}
         onHighlightClick={onHighlightClick}
+        activeSentenceId={activeSentenceId}
+        onWheel={handleWheel}
       />
       <EditorTextarea
         ref={textareaRef}

--- a/src/components/Editor/EditorContainer.tsx
+++ b/src/components/Editor/EditorContainer.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 import type { Sentence } from "@/types/sentence";
 
@@ -12,6 +12,7 @@ interface EditorContainerProps {
   disabled?: boolean;
   sentences: Sentence[];
   onHighlightClick: (id: string) => void;
+  activeSentenceId: string | null;
 }
 
 const EditorContainer = ({
@@ -21,6 +22,7 @@ const EditorContainer = ({
   disabled,
   sentences,
   onHighlightClick,
+  activeSentenceId,
 }: EditorContainerProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -30,6 +32,19 @@ const EditorContainer = ({
       overlayRef.current.scrollTop = textareaRef.current.scrollTop;
     }
   };
+
+  // 패널에서 카드 클릭 시 에디터 스크롤
+  useEffect(() => {
+    if (!activeSentenceId || !overlayRef.current || !textareaRef.current) return;
+
+    const targetSpan = overlayRef.current.querySelector(`#${activeSentenceId}`);
+    if (targetSpan instanceof HTMLElement) {
+      textareaRef.current.scrollTo({
+        top: targetSpan.offsetTop,
+        behavior: "smooth",
+      });
+    }
+  }, [activeSentenceId]);
 
   return (
     <div

--- a/src/components/Editor/EditorContainer.tsx
+++ b/src/components/Editor/EditorContainer.tsx
@@ -1,9 +1,13 @@
-import { type WheelEvent, useEffect, useRef } from "react";
+import { type Ref, type WheelEvent, useImperativeHandle, useRef } from "react";
 
 import type { Sentence } from "@/types/sentence";
 
 import EditorTextarea from "./EditorTextarea";
 import HighlightOverlay from "./HighlightOverlay";
+
+export interface EditorContainerHandle {
+  scrollToSentence: (id: string) => void;
+}
 
 interface EditorContainerProps {
   text: string;
@@ -13,6 +17,7 @@ interface EditorContainerProps {
   sentences: Sentence[];
   onHighlightClick: (id: string) => void;
   activeSentenceId: string | null;
+  ref: Ref<EditorContainerHandle>;
 }
 
 const EditorContainer = ({
@@ -23,9 +28,26 @@ const EditorContainer = ({
   sentences,
   onHighlightClick,
   activeSentenceId,
+  ref,
 }: EditorContainerProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const spanRefs = useRef<Map<string, HTMLSpanElement>>(new Map());
+
+  useImperativeHandle(ref, () => ({
+    scrollToSentence: (id: string) => {
+      if (!textareaRef.current) return;
+
+      const targetSpan = spanRefs.current.get(id);
+
+      if (targetSpan) {
+        textareaRef.current.scrollTo({
+          top: targetSpan.offsetTop,
+          behavior: "smooth",
+        });
+      }
+    },
+  }));
 
   const handleScroll = () => {
     if (overlayRef.current && textareaRef.current) {
@@ -41,18 +63,13 @@ const EditorContainer = ({
     }
   };
 
-  // 패널에서 카드 클릭 시 에디터 스크롤
-  useEffect(() => {
-    if (!activeSentenceId || !overlayRef.current || !textareaRef.current) return;
-
-    const targetSpan = overlayRef.current.querySelector(`#${activeSentenceId}`);
-    if (targetSpan instanceof HTMLElement) {
-      textareaRef.current.scrollTo({
-        top: targetSpan.offsetTop,
-        behavior: "smooth",
-      });
+  const handleSpanRef = (id: string, node: HTMLSpanElement | null) => {
+    if (node) {
+      spanRefs.current.set(id, node);
+    } else {
+      spanRefs.current.delete(id);
     }
-  }, [activeSentenceId]);
+  };
 
   return (
     <div
@@ -71,6 +88,7 @@ const EditorContainer = ({
         onHighlightClick={onHighlightClick}
         activeSentenceId={activeSentenceId}
         onWheel={handleWheel}
+        onSpanRef={handleSpanRef}
       />
       <EditorTextarea
         ref={textareaRef}

--- a/src/components/Editor/EditorSection.tsx
+++ b/src/components/Editor/EditorSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type Ref, useState } from "react";
 
 import { FileText, Loader2, Search, Sparkles } from "lucide-react";
 
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { mockEditorText, mockSentences } from "@/mocks/sentences";
 import type { Sentence } from "@/types/sentence";
 
-import EditorContainer from "./EditorContainer";
+import EditorContainer, { type EditorContainerHandle } from "./EditorContainer";
 
 interface EditorSectionProps {
   text: string;
@@ -16,6 +16,7 @@ interface EditorSectionProps {
   onSubmit: (sentences: Sentence[]) => void;
   activeSentenceId: string | null;
   onHighlightClick: (id: string) => void;
+  ref: Ref<EditorContainerHandle>;
 }
 
 const EditorSection = ({
@@ -25,6 +26,7 @@ const EditorSection = ({
   onSubmit,
   activeSentenceId,
   onHighlightClick,
+  ref,
 }: EditorSectionProps) => {
   const [isChecking, setIsChecking] = useState<boolean>(false);
 
@@ -85,6 +87,7 @@ const EditorSection = ({
       {/* 에디터 */}
       <div className="m-4 flex min-h-0 flex-1 flex-col">
         <EditorContainer
+          ref={ref}
           text={text}
           onTextChange={onTextChange}
           placeholder="팩트체크할 텍스트를 입력하거나 붙여넣기 하세요..."

--- a/src/components/Editor/EditorSection.tsx
+++ b/src/components/Editor/EditorSection.tsx
@@ -14,9 +14,18 @@ interface EditorSectionProps {
   onTextChange: (text: string) => void;
   sentences: Sentence[];
   onSubmit: (sentences: Sentence[]) => void;
+  activeSentenceId: string | null;
+  onHighlightClick: (id: string) => void;
 }
 
-const EditorSection = ({ text, onTextChange, sentences, onSubmit }: EditorSectionProps) => {
+const EditorSection = ({
+  text,
+  onTextChange,
+  sentences,
+  onSubmit,
+  activeSentenceId,
+  onHighlightClick,
+}: EditorSectionProps) => {
   const [isChecking, setIsChecking] = useState<boolean>(false);
 
   // TODO(REMOVE): API 연동 후 삭제 - 샘플 버튼 핸들러
@@ -34,11 +43,6 @@ const EditorSection = ({ text, onTextChange, sentences, onSubmit }: EditorSectio
       onSubmit(mockSentences);
       setIsChecking(false);
     }, 1000);
-  };
-
-  const handleHighlightClick = (sentenceId: string) => {
-    console.log("Clicked sentence:", sentenceId);
-    // TODO(FE-06): 결과 패널 카드 활성화
   };
 
   return (
@@ -86,7 +90,8 @@ const EditorSection = ({ text, onTextChange, sentences, onSubmit }: EditorSectio
           placeholder="팩트체크할 텍스트를 입력하거나 붙여넣기 하세요..."
           disabled={isChecking}
           sentences={sentences}
-          onHighlightClick={handleHighlightClick}
+          onHighlightClick={onHighlightClick}
+          activeSentenceId={activeSentenceId}
         />
       </div>
     </div>

--- a/src/components/Editor/EditorSection.tsx
+++ b/src/components/Editor/EditorSection.tsx
@@ -39,7 +39,6 @@ const EditorSection = ({
     setIsChecking(true);
     // TODO(FE-14): POST /factcheck API 연동
     setTimeout(() => {
-      // 결과를 상위 컴포넌트로 전달
       onSubmit(mockSentences);
       setIsChecking(false);
     }, 1000);
@@ -56,7 +55,7 @@ const EditorSection = ({
           </div>
           {text.length > 0 && (
             <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
-              {text.length.toLocaleString()}자
+              {text.length.toLocaleString()}
             </span>
           )}
         </div>

--- a/src/components/Editor/EditorSection.tsx
+++ b/src/components/Editor/EditorSection.tsx
@@ -55,7 +55,8 @@ const EditorSection = ({
           </div>
           {text.length > 0 && (
             <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
-              {text.length.toLocaleString()}
+              {/* 아래는 총 글자 수를 지정하는 문구이므로 "자" 삭제하지 말 것 */}
+              {text.length.toLocaleString()}자
             </span>
           )}
         </div>

--- a/src/components/Editor/HighlightOverlay.tsx
+++ b/src/components/Editor/HighlightOverlay.tsx
@@ -1,4 +1,4 @@
-import type { Ref } from "react";
+import type { Ref, WheelEvent } from "react";
 
 import { type Sentence, isClaim } from "@/types/sentence";
 import { calculateIndices } from "@/utils/calculateIndices";
@@ -10,22 +10,40 @@ interface HighlightOverlayProps {
   text: string;
   sentences: Sentence[];
   onHighlightClick: (id: string) => void;
+  activeSentenceId: string | null;
+  onWheel: (e: WheelEvent<HTMLDivElement>) => void;
   ref: Ref<HTMLDivElement>;
 }
 
-const HighlightOverlay = ({ text, sentences, onHighlightClick, ref }: HighlightOverlayProps) => {
+const HighlightOverlay = ({
+  text,
+  sentences,
+  onHighlightClick,
+  activeSentenceId,
+  onWheel,
+  ref,
+}: HighlightOverlayProps) => {
   // "무시됨" 상태의 문장은 하이라이트에서 제외 (plain text로 표시)
   const activeSentences = sentences.filter((s) => !(isClaim(s) && s.status === "ignored"));
   const sentencesWithIndices = calculateIndices(text, activeSentences);
   const segments = createHighlightSegments(text, sentencesWithIndices);
 
   return (
-    <div ref={ref} className="editor-layer pointer-events-none text-transparent z-10">
+    <div
+      ref={ref}
+      className="editor-overlay pointer-events-none text-transparent z-10"
+      onWheel={onWheel}
+    >
       {segments.map((segment) =>
         segment.type === "plain" ? (
           <span key={segment.key}>{segment.content}</span>
         ) : (
-          <HighlightSpan key={segment.key} sentence={segment.sentence} onClick={onHighlightClick} />
+          <HighlightSpan
+            key={segment.key}
+            sentence={segment.sentence}
+            onClick={onHighlightClick}
+            isActive={segment.sentence.id === activeSentenceId}
+          />
         ),
       )}
     </div>

--- a/src/components/Editor/HighlightOverlay.tsx
+++ b/src/components/Editor/HighlightOverlay.tsx
@@ -13,6 +13,7 @@ interface HighlightOverlayProps {
   activeSentenceId: string | null;
   onWheel: (e: WheelEvent<HTMLDivElement>) => void;
   ref: Ref<HTMLDivElement>;
+  onSpanRef: (id: string, node: HTMLSpanElement | null) => void;
 }
 
 const HighlightOverlay = ({
@@ -22,6 +23,7 @@ const HighlightOverlay = ({
   activeSentenceId,
   onWheel,
   ref,
+  onSpanRef,
 }: HighlightOverlayProps) => {
   // "무시됨" 상태의 문장은 하이라이트에서 제외 (plain text로 표시)
   const activeSentences = sentences.filter((s) => !(isClaim(s) && s.status === "ignored"));
@@ -43,6 +45,7 @@ const HighlightOverlay = ({
             sentence={segment.sentence}
             onClick={onHighlightClick}
             isActive={segment.sentence.id === activeSentenceId}
+            ref={(node) => onSpanRef(segment.sentence.id, node)}
           />
         ),
       )}

--- a/src/components/Editor/HighlightSpan.tsx
+++ b/src/components/Editor/HighlightSpan.tsx
@@ -16,7 +16,7 @@ const HighlightSpan = ({ sentence, onClick }: HighlightSpanProps) => {
   const className = isClaim(sentence) ? HIGHLIGHT_CLASS[sentence.verdict] : HIGHLIGHT_CLASS.opinion;
 
   return (
-    <span className={className} onClick={() => onClick(sentence.id)}>
+    <span id={sentence.id} className={className} onClick={() => onClick(sentence.id)}>
       {sentence.text}
     </span>
   );

--- a/src/components/Editor/HighlightSpan.tsx
+++ b/src/components/Editor/HighlightSpan.tsx
@@ -1,11 +1,17 @@
-// Tailwind safelist: highlight-true-active highlight-false-active highlight-opinion-active
 import type { SentenceWithIndices } from "@/types/sentence";
 import { isClaim } from "@/types/sentence";
 
 const HIGHLIGHT_CLASS = {
-  TRUE: "highlight-true",
-  FALSE: "highlight-false",
-  opinion: "highlight-opinion",
+  default: {
+    TRUE: "highlight-true",
+    FALSE: "highlight-false",
+    opinion: "highlight-opinion",
+  },
+  active: {
+    TRUE: "highlight-true-active",
+    FALSE: "highlight-false-active",
+    opinion: "highlight-opinion-active",
+  },
 } as const;
 
 interface HighlightSpanProps {
@@ -15,9 +21,9 @@ interface HighlightSpanProps {
 }
 
 const HighlightSpan = ({ sentence, onClick, isActive }: HighlightSpanProps) => {
-  const baseClass = isClaim(sentence) ? HIGHLIGHT_CLASS[sentence.verdict] : HIGHLIGHT_CLASS.opinion;
-
-  const className = isActive ? `${baseClass}-active` : baseClass;
+  const key = isClaim(sentence) ? sentence.verdict : "opinion";
+  const state = isActive ? "active" : "default";
+  const className = HIGHLIGHT_CLASS[state][key];
 
   return (
     <span id={sentence.id} className={className} onClick={() => onClick(sentence.id)}>

--- a/src/components/Editor/HighlightSpan.tsx
+++ b/src/components/Editor/HighlightSpan.tsx
@@ -1,3 +1,4 @@
+// Tailwind safelist: highlight-true-active highlight-false-active highlight-opinion-active
 import type { SentenceWithIndices } from "@/types/sentence";
 import { isClaim } from "@/types/sentence";
 
@@ -10,10 +11,13 @@ const HIGHLIGHT_CLASS = {
 interface HighlightSpanProps {
   sentence: SentenceWithIndices;
   onClick: (id: string) => void;
+  isActive: boolean;
 }
 
-const HighlightSpan = ({ sentence, onClick }: HighlightSpanProps) => {
-  const className = isClaim(sentence) ? HIGHLIGHT_CLASS[sentence.verdict] : HIGHLIGHT_CLASS.opinion;
+const HighlightSpan = ({ sentence, onClick, isActive }: HighlightSpanProps) => {
+  const baseClass = isClaim(sentence) ? HIGHLIGHT_CLASS[sentence.verdict] : HIGHLIGHT_CLASS.opinion;
+
+  const className = isActive ? `${baseClass}-active` : baseClass;
 
   return (
     <span id={sentence.id} className={className} onClick={() => onClick(sentence.id)}>

--- a/src/components/Editor/HighlightSpan.tsx
+++ b/src/components/Editor/HighlightSpan.tsx
@@ -1,3 +1,5 @@
+import type { Ref } from "react";
+
 import type { SentenceWithIndices } from "@/types/sentence";
 import { isClaim } from "@/types/sentence";
 
@@ -18,15 +20,16 @@ interface HighlightSpanProps {
   sentence: SentenceWithIndices;
   onClick: (id: string) => void;
   isActive: boolean;
+  ref: Ref<HTMLSpanElement>;
 }
 
-const HighlightSpan = ({ sentence, onClick, isActive }: HighlightSpanProps) => {
+const HighlightSpan = ({ sentence, onClick, isActive, ref }: HighlightSpanProps) => {
   const key = isClaim(sentence) ? sentence.verdict : "opinion";
   const state = isActive ? "active" : "default";
   const className = HIGHLIGHT_CLASS[state][key];
 
   return (
-    <span id={sentence.id} className={className} onClick={() => onClick(sentence.id)}>
+    <span ref={ref} id={sentence.id} className={className} onClick={() => onClick(sentence.id)}>
       {sentence.text}
     </span>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -145,36 +145,62 @@
   @apply absolute inset-0 overflow-auto;
   @apply font-editor text-editor leading-editor p-editor tracking-editor;
   @apply whitespace-pre-wrap wrap-break-word;
+  /* 스크롤바 숨기기 - overlay와 textarea의 clientWidth 일치 */
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+  &::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera */
+  }
+}
+
+@utility editor-overlay {
+  @apply editor-layer overflow-hidden;
 }
 
 /* Highlight styles - 팩트체크 결과 하이라이팅 (그라데이션 배경) */
 @utility highlight-base {
-  @apply rounded cursor-pointer pointer-events-auto;
+  @apply cursor-pointer pointer-events-auto;
   @apply transition-all duration-200;
+  display: inline;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
 }
 
 @utility highlight-true {
   @apply highlight-base;
-  background: linear-gradient(to bottom, transparent 60%, var(--verdict-true-bg) 60%);
+  background: linear-gradient(to bottom, transparent 80%, var(--verdict-true-bg) 80%);
   &:hover {
-    background: linear-gradient(to bottom, transparent 50%, var(--verdict-true-bg-hover) 50%);
+    background: linear-gradient(to bottom, transparent 70%, var(--verdict-true-bg-hover) 70%);
   }
 }
 
 @utility highlight-false {
   @apply highlight-base;
-  background: linear-gradient(to bottom, transparent 60%, var(--verdict-false-bg) 60%);
+  background: linear-gradient(to bottom, transparent 80%, var(--verdict-false-bg) 80%);
   &:hover {
-    background: linear-gradient(to bottom, transparent 50%, var(--verdict-false-bg-hover) 50%);
+    background: linear-gradient(to bottom, transparent 70%, var(--verdict-false-bg-hover) 70%);
   }
 }
 
 @utility highlight-opinion {
   @apply highlight-base;
-  background: linear-gradient(to bottom, transparent 60%, var(--verdict-opinion-bg) 60%);
+  background: linear-gradient(to bottom, transparent 80%, var(--verdict-opinion-bg) 80%);
   &:hover {
-    background: linear-gradient(to bottom, transparent 50%, var(--verdict-opinion-bg-hover) 50%);
+    background: linear-gradient(to bottom, transparent 70%, var(--verdict-opinion-bg-hover) 70%);
   }
+}
+
+@utility highlight-true-active {
+  @apply highlight-base;
+  background: linear-gradient(to bottom, transparent 0%, var(--verdict-true-bg) 0%);
+}
+
+@utility highlight-false-active {
+  @apply highlight-base;
+  background: linear-gradient(to bottom, transparent 0%, var(--verdict-false-bg) 0%);
+}
+
+@utility highlight-opinion-active {
+  @apply highlight-base;
+  background: linear-gradient(to bottom, transparent 0%, var(--verdict-opinion-bg) 0%);
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { AnalyzePanel } from "@/components/Analyze/AnalyzePanel";
+import AnalyzePanel from "@/components/Analyze/AnalyzePanel";
 import EditorSection from "@/components/Editor/EditorSection";
 import type { Sentence } from "@/types/sentence";
 import { isClaim } from "@/types/sentence";

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,8 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import AnalyzePanel from "@/components/Analyze/AnalyzePanel";
+import type { ResultsPanelHandle } from "@/components/Analyze/ResultsPanel";
+import type { EditorContainerHandle } from "@/components/Editor/EditorContainer";
 import EditorSection from "@/components/Editor/EditorSection";
 import type { Sentence } from "@/types/sentence";
 import { isClaim } from "@/types/sentence";
@@ -10,6 +12,9 @@ export const HomePage = () => {
   const [text, setText] = useState<string>("");
   const [sentences, setSentences] = useState<Sentence[]>([]);
   const [activeSentenceId, setActiveSentenceId] = useState<string | null>(null);
+
+  const editorRef = useRef<EditorContainerHandle>(null);
+  const panelRef = useRef<ResultsPanelHandle>(null);
 
   const handleSubmit = (newSentences: Sentence[]) => {
     setSentences(newSentences);
@@ -62,11 +67,17 @@ export const HomePage = () => {
   // 에디터 하이라이트 클릭 → 패널 카드로 스크롤
   const handleHighlightClick = (id: string) => {
     setActiveSentenceId(id);
+    if (panelRef.current) {
+      panelRef.current.scrollToCard(id);
+    }
   };
 
   // 패널 카드 클릭 → 에디터 문장으로 스크롤
   const handleCardClick = (id: string) => {
     setActiveSentenceId(id);
+    if (editorRef.current) {
+      editorRef.current.scrollToSentence(id);
+    }
   };
 
   return (
@@ -74,6 +85,7 @@ export const HomePage = () => {
       {/* Editor Column */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden lg:w-[60%]">
         <EditorSection
+          ref={editorRef}
           text={text}
           onTextChange={setText}
           sentences={sentences}
@@ -86,6 +98,7 @@ export const HomePage = () => {
       {/* Results/History Column */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden border-l border-border lg:w-[40%] lg:flex-none">
         <AnalyzePanel
+          ref={panelRef}
           sentences={sentences}
           onApply={handleApply}
           onIgnore={handleIgnore}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,6 +9,7 @@ import { calculateIndices } from "@/utils/calculateIndices";
 export const HomePage = () => {
   const [text, setText] = useState<string>("");
   const [sentences, setSentences] = useState<Sentence[]>([]);
+  const [activeSentenceId, setActiveSentenceId] = useState<string | null>(null);
 
   const handleSubmit = (newSentences: Sentence[]) => {
     setSentences(newSentences);
@@ -58,6 +59,16 @@ export const HomePage = () => {
     );
   };
 
+  // 에디터 하이라이트 클릭 → 패널 카드로 스크롤
+  const handleHighlightClick = (id: string) => {
+    setActiveSentenceId(id);
+  };
+
+  // 패널 카드 클릭 → 에디터 문장으로 스크롤
+  const handleCardClick = (id: string) => {
+    setActiveSentenceId(id);
+  };
+
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col lg:flex-row">
       {/* Editor Column */}
@@ -67,12 +78,20 @@ export const HomePage = () => {
           onTextChange={setText}
           sentences={sentences}
           onSubmit={handleSubmit}
+          activeSentenceId={activeSentenceId}
+          onHighlightClick={handleHighlightClick}
         />
       </div>
 
       {/* Results/History Column */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden border-l border-border lg:w-[40%] lg:flex-none">
-        <AnalyzePanel sentences={sentences} onApply={handleApply} onIgnore={handleIgnore} />
+        <AnalyzePanel
+          sentences={sentences}
+          onApply={handleApply}
+          onIgnore={handleIgnore}
+          activeSentenceId={activeSentenceId}
+          onCardClick={handleCardClick}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)
- Closes #11
## 🛠️ 작업 내용 (Description)
* 에디터와 결과 패널 간의 상호작용 및 정렬 이슈를 해결
### **AS-IS**
* 에디터와 결과 패널 간 연동 기능 없음 (하이라이트 클릭 시 결과 카드로 이동 불가)
* 결과 카드 클릭 시 에디터 문장으로 이동 불가
* Textarea와 Overlay스크롤 동기화 불안정 (빠른 스크롤 시 하이라이트 밀림 현상)
### **TO-BE**
* 양방향 스크롤 연동
    * 에디터 하이라이트 클릭 ↔ 결과 패널 카드 간 부드러운 스크롤 이동 구현
* 스크롤 동기화 최적화 
    * handleWheel 핸들러로 오버레이 휠 이벤트를 textarea로 전달
    * 즉시 동기화(sync) 처리
* 정렬 버그 수정
    * CSS로 textarea 스크롤바 숨김(scrollbar-width: none) 처리하여 overlay와 너비를 통일함
* 활성 상태 스타일 추가
    * 선택된 문장 하이라이트 시 active 스타일(진한 배경) 적용
## 📸 스크린샷 (Screenshots - Optional)
| 모바일 | 데스크탑 |
| :---: | :---: |
| <img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/3097a1e9-0a88-45c7-af9d-24768d116326" /> | <img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/6b9128db-b350-4bb6-b53c-bf533b9c6045" /> |

### Textarea와 Overlay스크롤 동기화 불안정 해결
| Before | After |
| :---: | :---: |
| <img width="300" height="38" alt="image" src="https://github.com/user-attachments/assets/fdff7c1b-b756-4746-919a-9cd9806fcc24" /> | <img width="300" height="38" alt="image" src="https://github.com/user-attachments/assets/ad340ace-740c-4c12-a7ba-398b8c963551" /> |
## ✅ 체크리스트 (Self Checklist)
**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요?
- [x] (필요 시) 관련 문서나 API 명세서를 업데이트했나요?

**UI / UX (해당 시)**
- [x] 다양한 화면 크기(모바일/데스크탑)에서 깨짐이 없나요?
- [x] 주요 브라우저에서 동작을 확인했나요? (Chrome, Safari에서 스크롤바 숨김 테스트)

**안정성 및 배포**
- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요? (변경 사항 없음)
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?
## 🧪 테스트 방법 (How to Test)
1. **스크롤 동기화**
* 에디터에 긴 텍스트를 입력하고 마우스 휠 및 스크롤바 드래그 시 하이라이트가 텍스트에 딱 붙어서 움직이는지 확인
2. **줄바꿈 정렬**
* 창 크기를 줄여 줄바꿈이 일어날 때, 하이라이트 배경 위치가 실제 텍스트와 정확히 일치하는지 확인
3. **양방향 인터랙션**
* 에디터에서 하이라이트 클릭 시 결과 패널 카드로 이동
* 결과 패널 카드 클릭 시 에디터 문장으로 이동하는지 확인
## ⚠️ 특이사항 (Notes)
- `textarea`의 스크롤바를 CSS로 숨겼으므로, 긴 텍스트 스크롤 시 마우스 휠이나 트랙패드 사용이 필요