### PR TITLE
feat: 하이라이트 인덱스 동기화 개선 (#16)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,10 +1,11 @@
 import axios from "axios";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
+const API_TIMEOUT_MS = 60000;
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 60000,
+  timeout: API_TIMEOUT_MS,
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -4,7 +4,7 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 10000,
+  timeout: 60000,
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/components/Editor/EditorContainer.tsx
+++ b/src/components/Editor/EditorContainer.tsx
@@ -1,6 +1,6 @@
 import { type Ref, type WheelEvent, useImperativeHandle, useRef } from "react";
 
-import type { Sentence } from "@/types/factcheck";
+import type { SentenceWithIndices } from "@/types/factcheck";
 
 import EditorTextarea from "./EditorTextarea";
 import HighlightOverlay from "./HighlightOverlay";
@@ -14,7 +14,7 @@ interface EditorContainerProps {
   onTextChange: (text: string) => void;
   placeholder: string;
   disabled?: boolean;
-  sentences: Sentence[];
+  sentences: SentenceWithIndices[];
   onHighlightClick: (id: string) => void;
   activeSentenceId: string | null;
   ref: Ref<EditorContainerHandle>;

--- a/src/components/Editor/EditorSection.tsx
+++ b/src/components/Editor/EditorSection.tsx
@@ -5,14 +5,14 @@ import { FileText, Loader2, Search, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 // TODO(REMOVE): API 연동 후 삭제 - 목 데이터 import
 import { mockEditorText } from "@/mocks/sentences";
-import type { Sentence } from "@/types/factcheck";
+import type { SentenceWithIndices } from "@/types/factcheck";
 
 import EditorContainer, { type EditorContainerHandle } from "./EditorContainer";
 
 interface EditorSectionProps {
   text: string;
   onTextChange: (text: string) => void;
-  sentences: Sentence[];
+  sentences: SentenceWithIndices[];
   onCheck: () => void;
   isPending: boolean;
   onClearSentences: () => void;

--- a/src/components/Editor/HighlightOverlay.tsx
+++ b/src/components/Editor/HighlightOverlay.tsx
@@ -1,14 +1,13 @@
 import type { Ref, WheelEvent } from "react";
 
-import { type Sentence, isClaim } from "@/types/factcheck";
-import { calculateIndices } from "@/utils/calculateIndices";
+import { type SentenceWithIndices, isClaim } from "@/types/factcheck";
 import { createHighlightSegments } from "@/utils/createHighlightSegments";
 
 import HighlightSpan from "./HighlightSpan";
 
 interface HighlightOverlayProps {
   text: string;
-  sentences: Sentence[];
+  sentences: SentenceWithIndices[];
   onHighlightClick: (id: string) => void;
   activeSentenceId: string | null;
   onWheel: (e: WheelEvent<HTMLDivElement>) => void;
@@ -25,10 +24,9 @@ const HighlightOverlay = ({
   ref,
   onSpanRef,
 }: HighlightOverlayProps) => {
-  // "무시됨" 상태의 문장은 하이라이트에서 제외 (plain text로 표시)
-  const activeSentences = sentences.filter((s) => !(isClaim(s) && s.status === "ignored"));
-  const sentencesWithIndices = calculateIndices(text, activeSentences);
-  const segments = createHighlightSegments(text, sentencesWithIndices);
+  const isIgnoredClaim = (s: SentenceWithIndices) => isClaim(s) && s.status === "ignored";
+  const activeSentences = sentences.filter((s) => !isIgnoredClaim(s));
+  const segments = createHighlightSegments(text, activeSentences);
 
   return (
     <div

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,13 +9,15 @@ import {
   useFactCheckMutation,
   useIgnoreClaimMutation,
 } from "@/hooks/mutations/useFactCheckMutations";
-import type { Sentence } from "@/types/factcheck";
+import type { SentenceWithIndices } from "@/types/factcheck";
 import { isClaim } from "@/types/factcheck";
+import { adjustIndices } from "@/utils/adjustIndices";
 import { calculateIndices } from "@/utils/calculateIndices";
+import { findEditDelta } from "@/utils/findEditDelta";
 
 export const HomePage = () => {
   const [text, setText] = useState<string>("");
-  const [sentences, setSentences] = useState<Sentence[]>([]);
+  const [sentences, setSentences] = useState<SentenceWithIndices[]>([]);
   const [activeSentenceId, setActiveSentenceId] = useState<string | null>(null);
   const [factcheckId, setFactcheckId] = useState<string>("");
 
@@ -31,7 +33,8 @@ export const HomePage = () => {
     submitFactCheck(text, {
       onSuccess: (data) => {
         setFactcheckId(data.id);
-        setSentences(data.sentences);
+        const withIndices = calculateIndices(text, data.sentences);
+        setSentences(withIndices);
       },
       onError: (error) => {
         console.error(error);
@@ -45,33 +48,45 @@ export const HomePage = () => {
     setSentences([]);
   };
 
+  const handleTextChange = (newText: string) => {
+    if (sentences.length > 0) {
+      const { editStart, editEnd, delta } = findEditDelta(text, newText);
+      setSentences((prev) => adjustIndices(prev, editStart, editEnd, delta));
+    }
+    setText(newText);
+  };
+
   const handleApply = (id: string) => {
     if (!factcheckId) return;
 
-    const sentencesWithIndices = calculateIndices(text, sentences);
-    const target = sentencesWithIndices.find((s) => s.id === id);
+    const target = sentences.find((s) => s.id === id);
 
-    if (!target || !isClaim(target) || !target.suggestion) {
+    if (!target || !isClaim(target) || !target.suggestion || target.startIndex === -1) {
       return;
     }
 
     const newEditorText =
       text.slice(0, target.startIndex) + target.suggestion + text.slice(target.endIndex);
-    setText(newEditorText);
 
-    setSentences((prev) =>
-      prev.map((sentence) => {
+    const delta = target.suggestion.length - target.text.length;
+
+    setSentences((prev) => {
+      const updated = prev.map((sentence) => {
         if (sentence.id === id && isClaim(sentence) && sentence.suggestion) {
           return {
             ...sentence,
             text: sentence.suggestion,
             verdict: "TRUE" as const,
             status: "applied" as const,
+            endIndex: sentence.startIndex + sentence.suggestion.length,
           };
         }
         return sentence;
-      }),
-    );
+      });
+      return adjustIndices(updated, target.startIndex, target.endIndex, delta);
+    });
+
+    setText(newEditorText);
 
     applyClaim(
       { factcheckId, claimId: id },
@@ -120,6 +135,11 @@ export const HomePage = () => {
   };
 
   const handleCardClick = (id: string) => {
+    const target = sentences.find((s) => s.id === id);
+    if (!target || target.startIndex === -1) {
+      return;
+    }
+
     setActiveSentenceId(id);
     if (editorRef.current) {
       editorRef.current.scrollToSentence(id);
@@ -133,7 +153,7 @@ export const HomePage = () => {
         <EditorSection
           ref={editorRef}
           text={text}
-          onTextChange={setText}
+          onTextChange={handleTextChange}
           sentences={sentences}
           onCheck={handleCheck}
           isPending={isPending}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -71,19 +71,21 @@ export const HomePage = () => {
     const delta = target.suggestion.length - target.text.length;
 
     setSentences((prev) => {
-      const updated = prev.map((sentence) => {
+      const adjusted = adjustIndices(prev, target.startIndex, target.endIndex, delta);
+
+      return adjusted.map((sentence) => {
         if (sentence.id === id && isClaim(sentence) && sentence.suggestion) {
           return {
             ...sentence,
             text: sentence.suggestion,
             verdict: "TRUE" as const,
             status: "applied" as const,
-            endIndex: sentence.startIndex + sentence.suggestion.length,
+            startIndex: target.startIndex,
+            endIndex: target.startIndex + sentence.suggestion.length,
           };
         }
         return sentence;
       });
-      return adjustIndices(updated, target.startIndex, target.endIndex, delta);
     });
 
     setText(newEditorText);
@@ -129,6 +131,7 @@ export const HomePage = () => {
 
   const handleHighlightClick = (id: string) => {
     setActiveSentenceId(id);
+
     if (panelRef.current) {
       panelRef.current.scrollToCard(id);
     }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -135,12 +135,13 @@ export const HomePage = () => {
   };
 
   const handleCardClick = (id: string) => {
+    setActiveSentenceId(id);
+
     const target = sentences.find((s) => s.id === id);
     if (!target || target.startIndex === -1) {
       return;
     }
 
-    setActiveSentenceId(id);
     if (editorRef.current) {
       editorRef.current.scrollToSentence(id);
     }

--- a/src/utils/adjustIndices.spec.ts
+++ b/src/utils/adjustIndices.spec.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import type { ClaimSentence, SentenceWithIndices } from "@/types/factcheck";
+
+import { adjustIndices } from "./adjustIndices";
+
+type ClaimWithIndices = ClaimSentence & { startIndex: number; endIndex: number };
+
+const createSentence = (
+  startIndex: number,
+  endIndex: number,
+  overrides?: Partial<ClaimWithIndices>,
+): SentenceWithIndices => ({
+  id: "test-id",
+  text: "테스트 문장",
+  position: 0,
+  type: "claim" as const,
+  verdict: "TRUE",
+  sources: [],
+  status: "pending",
+  suggestion: null,
+  startIndex,
+  endIndex,
+  ...overrides,
+});
+
+describe("adjustIndices", () => {
+  describe("수정 영역 이전 문장", () => {
+    it("수정 영역보다 앞에 있는 문장은 인덱스가 변경되지 않는다", () => {
+      const sentences = [createSentence(0, 10)];
+
+      const result = adjustIndices(sentences, 20, 25, 5);
+
+      expect(result[0]).toEqual(createSentence(0, 10));
+    });
+
+    it("수정 영역 시작점과 endIndex가 같은 문장은 변경되지 않는다", () => {
+      const sentences = [createSentence(0, 10)];
+
+      const result = adjustIndices(sentences, 10, 15, 5);
+
+      expect(result[0]).toEqual(createSentence(0, 10));
+    });
+  });
+
+  describe("수정 영역 이후 문장", () => {
+    it("수정 영역보다 뒤에 있는 문장은 delta만큼 인덱스가 이동한다", () => {
+      const sentences = [createSentence(30, 40)];
+
+      const result = adjustIndices(sentences, 10, 15, 5);
+
+      expect(result[0]).toEqual(createSentence(35, 45));
+    });
+
+    it("삭제(delta < 0)시 이후 문장의 인덱스가 감소한다", () => {
+      const sentences = [createSentence(30, 40)];
+
+      const result = adjustIndices(sentences, 10, 20, -10);
+
+      expect(result[0]).toEqual(createSentence(20, 30));
+    });
+
+    it("수정 영역 끝점과 startIndex가 같은 문장도 이동한다", () => {
+      const sentences = [createSentence(15, 25)];
+
+      const result = adjustIndices(sentences, 10, 15, 5);
+
+      expect(result[0]).toEqual(createSentence(20, 30));
+    });
+  });
+
+  describe("수정 영역과 겹치는 문장", () => {
+    it("수정 영역과 완전히 겹치는 문장은 무효화된다", () => {
+      const sentences = [createSentence(12, 18)];
+
+      const result = adjustIndices(sentences, 10, 20, 5);
+
+      expect(result[0].startIndex).toBe(-1);
+      expect(result[0].endIndex).toBe(-1);
+    });
+
+    it("수정 영역이 문장 시작 부분과 겹치면 무효화된다", () => {
+      const sentences = [createSentence(15, 25)];
+
+      const result = adjustIndices(sentences, 10, 20, 5);
+
+      expect(result[0].startIndex).toBe(-1);
+      expect(result[0].endIndex).toBe(-1);
+    });
+
+    it("수정 영역이 문장 끝 부분과 겹치면 무효화된다", () => {
+      const sentences = [createSentence(5, 15)];
+
+      const result = adjustIndices(sentences, 10, 20, 5);
+
+      expect(result[0].startIndex).toBe(-1);
+      expect(result[0].endIndex).toBe(-1);
+    });
+
+    it("문장이 수정 영역을 완전히 포함해도 무효화된다", () => {
+      const sentences = [createSentence(5, 25)];
+
+      const result = adjustIndices(sentences, 10, 20, 5);
+
+      expect(result[0].startIndex).toBe(-1);
+      expect(result[0].endIndex).toBe(-1);
+    });
+  });
+
+  describe("이미 무효화된 문장", () => {
+    it("이미 무효화된 문장(-1, -1)은 그대로 유지된다", () => {
+      const sentences = [createSentence(-1, -1)];
+
+      const result = adjustIndices(sentences, 10, 20, 5);
+
+      expect(result[0].startIndex).toBe(-1);
+      expect(result[0].endIndex).toBe(-1);
+    });
+  });
+
+  describe("여러 문장 처리", () => {
+    it("여러 문장이 있을 때 각각 올바르게 처리된다", () => {
+      const sentences = [
+        createSentence(0, 10), // 수정 영역 이전
+        createSentence(15, 25), // 수정 영역과 겹침
+        createSentence(30, 40), // 수정 영역 이후
+        createSentence(-1, -1), // 이미 무효화
+      ];
+
+      const result = adjustIndices(sentences, 12, 28, 10);
+
+      expect(result[0]).toEqual(createSentence(0, 10)); // 변경 없음
+      expect(result[1].startIndex).toBe(-1); // 무효화
+      expect(result[2]).toEqual(createSentence(40, 50)); // +10 이동
+      expect(result[3].startIndex).toBe(-1); // 그대로 무효
+    });
+  });
+
+  describe("경계 케이스", () => {
+    it("빈 배열은 빈 배열을 반환한다", () => {
+      const result = adjustIndices([], 10, 20, 5);
+
+      expect(result).toEqual([]);
+    });
+
+    it("delta가 0이어도 겹치는 문장은 무효화된다", () => {
+      const sentences = [createSentence(15, 25)];
+
+      const result = adjustIndices(sentences, 10, 20, 0);
+
+      expect(result[0].startIndex).toBe(-1);
+    });
+
+    it("원본 배열은 변경되지 않는다 (immutability)", () => {
+      const original = [createSentence(30, 40)];
+      const originalCopy = structuredClone(original);
+
+      adjustIndices(original, 10, 15, 5);
+
+      expect(original).toEqual(originalCopy);
+    });
+  });
+});

--- a/src/utils/adjustIndices.ts
+++ b/src/utils/adjustIndices.ts
@@ -1,0 +1,46 @@
+import type { SentenceWithIndices } from "@/types/factcheck";
+
+/**
+ * 텍스트 수정 후 문장들의 인덱스를 조정합니다.
+ *
+ * @param sentences - 인덱스가 포함된 문장 배열
+ * @param editStart - 수정이 시작된 위치 (기존 텍스트 기준)
+ * @param editEnd - 수정이 끝난 위치 (기존 텍스트 기준)
+ * @param delta - 텍스트 길이 변화량
+ * @returns 조정된 인덱스가 포함된 문장 배열
+ *
+ * @remarks
+ * - 수정 영역 이전의 문장: 변경 없음
+ * - 수정 영역 이후의 문장: delta만큼 인덱스 이동
+ * - 수정 영역과 겹치는 문장: 무효화 (startIndex, endIndex = -1)
+ */
+export const adjustIndices = (
+  sentences: SentenceWithIndices[],
+  editStart: number,
+  editEnd: number,
+  delta: number,
+): SentenceWithIndices[] => {
+  return sentences.map((sentence) => {
+    if (sentence.startIndex === -1) {
+      return sentence;
+    }
+
+    if (sentence.endIndex <= editStart) {
+      return sentence;
+    }
+
+    if (sentence.startIndex >= editEnd) {
+      return {
+        ...sentence,
+        startIndex: sentence.startIndex + delta,
+        endIndex: sentence.endIndex + delta,
+      };
+    }
+
+    return {
+      ...sentence,
+      startIndex: -1,
+      endIndex: -1,
+    };
+  });
+};

--- a/src/utils/findEditDelta.spec.ts
+++ b/src/utils/findEditDelta.spec.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import { findEditDelta } from "./findEditDelta";
+
+describe("findEditDelta", () => {
+  describe("삽입 케이스", () => {
+    it("중간에 텍스트를 삽입하면 editStart와 editEnd가 같고 delta가 양수다", () => {
+      const result = findEditDelta("Hello World", "Hello Beautiful World");
+
+      expect(result).toEqual({
+        editStart: 6,
+        editEnd: 6,
+        delta: 10,
+      });
+    });
+
+    it("맨 앞에 텍스트를 삽입하면 editStart가 0이다", () => {
+      const result = findEditDelta("World", "Hello World");
+
+      expect(result).toEqual({
+        editStart: 0,
+        editEnd: 0,
+        delta: 6,
+      });
+    });
+
+    it("맨 뒤에 텍스트를 삽입하면 editStart가 원본 길이와 같다", () => {
+      const result = findEditDelta("Hello", "Hello World");
+
+      expect(result).toEqual({
+        editStart: 5,
+        editEnd: 5,
+        delta: 6,
+      });
+    });
+
+    it("빈 문자열에 텍스트를 삽입하면 editStart가 0이다", () => {
+      const result = findEditDelta("", "new text");
+
+      expect(result).toEqual({
+        editStart: 0,
+        editEnd: 0,
+        delta: 8,
+      });
+    });
+  });
+
+  describe("삭제 케이스", () => {
+    it("중간 텍스트를 삭제하면 delta가 음수다", () => {
+      const result = findEditDelta("Hello Beautiful World", "Hello World");
+
+      expect(result).toEqual({
+        editStart: 6,
+        editEnd: 16,
+        delta: -10,
+      });
+    });
+
+    it("맨 앞 텍스트를 삭제하면 editStart가 0이다", () => {
+      const result = findEditDelta("Hello World", "World");
+
+      expect(result).toEqual({
+        editStart: 0,
+        editEnd: 6,
+        delta: -6,
+      });
+    });
+
+    it("맨 뒤 텍스트를 삭제하면 editEnd가 원본 길이와 같다", () => {
+      const result = findEditDelta("Hello World", "Hello");
+
+      expect(result).toEqual({
+        editStart: 5,
+        editEnd: 11,
+        delta: -6,
+      });
+    });
+
+    it("전체 텍스트를 삭제하면 빈 문자열이 된다", () => {
+      const result = findEditDelta("text", "");
+
+      expect(result).toEqual({
+        editStart: 0,
+        editEnd: 4,
+        delta: -4,
+      });
+    });
+  });
+
+  describe("교체 케이스", () => {
+    it("동일한 길이의 텍스트로 교체하면 delta가 0이다", () => {
+      const result = findEditDelta("abc", "xyz");
+
+      expect(result).toEqual({
+        editStart: 0,
+        editEnd: 3,
+        delta: 0,
+      });
+    });
+
+    it("부분 교체 시 공통 prefix/suffix를 제외한 범위만 반환한다", () => {
+      const result = findEditDelta("Hello World", "Hello Earth");
+
+      expect(result).toEqual({
+        editStart: 6,
+        editEnd: 11,
+        delta: 0,
+      });
+    });
+  });
+
+  describe("경계 케이스", () => {
+    it("동일한 텍스트면 editStart와 editEnd가 같고 delta가 0이다", () => {
+      const result = findEditDelta("same", "same");
+
+      expect(result).toEqual({
+        editStart: 4,
+        editEnd: 4,
+        delta: 0,
+      });
+    });
+
+    it("양쪽 모두 빈 문자열이면 모든 값이 0이다", () => {
+      const result = findEditDelta("", "");
+
+      expect(result).toEqual({
+        editStart: 0,
+        editEnd: 0,
+        delta: 0,
+      });
+    });
+
+    it("한 글자만 변경해도 정확히 감지한다", () => {
+      const result = findEditDelta("cat", "cut");
+
+      expect(result).toEqual({
+        editStart: 1,
+        editEnd: 2,
+        delta: 0,
+      });
+    });
+  });
+});

--- a/src/utils/findEditDelta.ts
+++ b/src/utils/findEditDelta.ts
@@ -1,0 +1,42 @@
+/**
+ * 두 문자열(oldText, newText)을 비교하여 수정 위치와 변경량(delta)을 계산합니다.
+ *
+ * @param oldText - 변경 전 텍스트
+ * @param newText - 변경 후 텍스트
+ * @returns { editStart, editEnd, delta }
+ *   - editStart: 수정이 시작된 위치 (oldText 기준)
+ *   - editEnd: 수정이 끝난 위치 (oldText 기준)
+ *   - delta: 텍스트 길이 변화량 (양수면 증가, 음수면 감소)
+ *
+ * @example
+ * findEditDelta("Hello World", "Hello Beautiful World")
+ * // Returns: { editStart: 6, editEnd: 6, delta: 10 }
+ */
+export const findEditDelta = (
+  oldText: string,
+  newText: string,
+): { editStart: number; editEnd: number; delta: number } => {
+  const hasSameCharAt = (index: number) => oldText[index] === newText[index];
+  const hasSameCharFromEnd = (oldIdx: number, newIdx: number) =>
+    oldText[oldIdx - 1] === newText[newIdx - 1];
+
+  const minLength = Math.min(oldText.length, newText.length);
+
+  let start = 0;
+  while (start < minLength && hasSameCharAt(start)) {
+    start++;
+  }
+
+  let oldEnd = oldText.length;
+  let newEnd = newText.length;
+  while (oldEnd > start && newEnd > start && hasSameCharFromEnd(oldEnd, newEnd)) {
+    oldEnd--;
+    newEnd--;
+  }
+
+  return {
+    editStart: start,
+    editEnd: oldEnd,
+    delta: newEnd - start - (oldEnd - start),
+  };
+};


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)
- Closes #16

## 🛠️ 작업 내용 (Description)
* 하이라이트 위치가 텍스트 수정 후 틀어지는 버그 수정

### **AS-IS**
* `calculateIndices`가 매번 `indexOf`로 텍스트 검색하여 인덱스 계산
* 동일한 문장이 2개 이상 있을 경우, 첫 번째 매칭 텍스트 위치만 찾음
* "수정 적용" 버튼 클릭 후 다른 카드 클릭 시 **잘못된 위치**로 하이라이트/스크롤

### **TO-BE**
* **오프셋 기반 인덱스 관리** 방식으로 전환
    * 최초 검사 시점에 인덱스 저장 → 이후 텍스트 변경 시 delta만 조정
* 유틸리티 함수 추가
    * `findEditDelta`: 텍스트 변경 위치/변경량 계산
    * `adjustIndices`: 인덱스 조정 (이동/무효화 처리)
* 하위 컴포넌트 타입 변경
    * `EditorSection`, `EditorContainer`, `HighlightOverlay`: `SentenceWithIndices[]` 타입 사용
    * `HighlightOverlay`에서 `calculateIndices` 매 렌더링 호출 제거

## ✅ 체크리스트 (Self Checklist)
**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요?
- [ ] (필요 시) 관련 문서나 API 명세서를 업데이트했나요?

**UI / UX (해당 시)**
- [x] 다양한 화면 크기(모바일/데스크탑)에서 깨짐이 없나요?
- [x] 주요 브라우저에서 동작을 확인했나요?

**안정성 및 배포**
- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요? (변경 사항 없음)
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 🧪 테스트 방법 (How to Test)
1. **동일 문장 복수 존재 시 하이라이트 정확성**
    * 동일한 문장 2개 이상 포함된 텍스트 입력 → "전체 검사" → 각 카드 클릭 시 올바른 위치로 스크롤 확인
2. **수정 적용 후 인덱스 정확성**
    * "수정 적용" 버튼 클릭 후 다른 카드 클릭 → 올바른 위치로 스크롤 확인
3. **직접 텍스트 수정 시 인덱스 조정**
    * 에디터에서 검사된 문장의 앞/뒤 텍스트 수정 → 다른 카드 클릭 → 인덱스 정상 조정 확인
4. **무효화된 문장 카드 클릭**
    * 검사된 문장을 직접 편집하여 무효화 → 카드 클릭 시 스크롤 비활성화 확인 (에러 없음)

## ⚠️ 특이사항 (Notes)
- 무효화된 문장(`startIndex === -1`)은 에디터 하이라이트가 제거되고, 카드 클릭 시 스크롤이 동작하지 않음
- **추후 개선 예정**: 무효화된 문장 카드에 "위치 확인 불가" 시각적 표시
- **추후 검토 필요**: `HomePage.tsx` 리팩토링 (커스텀 훅 분리 등)
