### PR TITLE
feat: 설정 페이지 UI 구현 및 API 연동 (#20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,11 @@
     "clsx": "^2.1.1",
     "dayjs": "^1.11.19",
     "lucide-react": "^0.562.0",
+    "next-themes": "^0.4.6",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-router": "^7.11.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",
     "zustand": "^5.0.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -53,6 +56,9 @@ importers:
       react-router:
         specifier: ^7.11.0
         version: 7.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -2547,6 +2553,12 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -2880,6 +2892,12 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5773,6 +5791,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-themes@0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   node-releases@2.0.27: {}
 
   object-assign@4.1.1: {}
@@ -6138,6 +6161,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  sonner@2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   source-map-js@1.2.1: {}
 

--- a/src/api/settingsApi.ts
+++ b/src/api/settingsApi.ts
@@ -1,0 +1,24 @@
+import type { SettingsResponse } from "@/types/settings";
+
+import { apiClient } from "./client";
+
+export const getSettings = async (): Promise<SettingsResponse> => {
+  const response = await apiClient.get<SettingsResponse>("/settings");
+  return response.data;
+};
+
+export const addWhitelistDomain = async (domain: string): Promise<void> => {
+  await apiClient.post("/settings/whitelist", { domain });
+};
+
+export const removeWhitelistDomain = async (domain: string): Promise<void> => {
+  await apiClient.delete(`/settings/whitelist/${encodeURIComponent(domain)}`);
+};
+
+export const addBlacklistDomain = async (domain: string): Promise<void> => {
+  await apiClient.post("/settings/blacklist", { domain });
+};
+
+export const removeBlacklistDomain = async (domain: string): Promise<void> => {
+  await apiClient.delete(`/settings/blacklist/${encodeURIComponent(domain)}`);
+};

--- a/src/components/Settings/DomainListEditor.tsx
+++ b/src/components/Settings/DomainListEditor.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+
+import { CheckCircle2, Plus, X, XCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface DomainListEditorProps {
+  title: string;
+  description: string;
+  variant: "whitelist" | "blacklist";
+  domains: string[];
+  onAdd: (domain: string) => void;
+  onRemove: (domain: string) => void;
+  isPending?: boolean;
+}
+
+const variantConfig = {
+  whitelist: {
+    icon: CheckCircle2,
+    iconColor: "text-(--verdict-true)",
+  },
+  blacklist: {
+    icon: XCircle,
+    iconColor: "text-(--verdict-false)",
+  },
+};
+
+const DomainListEditor = ({
+  title,
+  description,
+  variant,
+  domains,
+  onAdd,
+  onRemove,
+  isPending = false,
+}: DomainListEditorProps) => {
+  const [inputValue, setInputValue] = useState("");
+  const config = variantConfig[variant];
+  const Icon = config.icon;
+
+  const handleAdd = () => {
+    const trimmed = inputValue.trim().toLowerCase();
+    if (trimmed && !domains.includes(trimmed)) {
+      onAdd(trimmed);
+      setInputValue("");
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAdd();
+    }
+  };
+
+  return (
+    <Card className="flex flex-col gap-4 p-6">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <Icon className={cn("size-5", config.iconColor)} />
+        <h2 className="text-lg font-semibold">{title}</h2>
+      </div>
+      <p className="text-sm text-muted-foreground">{description}</p>
+
+      {/* Domain List */}
+      <div className="flex flex-col gap-2">
+        {domains.map((domain) => (
+          <div
+            key={domain}
+            className="flex items-center justify-between rounded-md border bg-background px-3 py-2"
+          >
+            <span className="text-sm">{domain}</span>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="size-8 text-muted-foreground hover:text-destructive"
+              onClick={() => onRemove(domain)}
+              disabled={isPending}
+            >
+              <X className="size-4" />
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      {/* Add Domain Input */}
+      <div className="flex gap-2">
+        <Input
+          placeholder="도메인 입력 (예: example.com)"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={isPending}
+          className="flex-1"
+        />
+        <Button onClick={handleAdd} disabled={isPending || !inputValue.trim()} className="gap-1.5">
+          <Plus className="size-4" />
+          추가
+        </Button>
+      </div>
+    </Card>
+  );
+};
+
+export default DomainListEditor;

--- a/src/components/Settings/DomainListEditor.tsx
+++ b/src/components/Settings/DomainListEditor.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
 
 import { CheckCircle2, Plus, X, XCircle } from "lucide-react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { validateDomain } from "@/utils/validateDomain";
 
 interface DomainListEditorProps {
   title: string;
@@ -38,15 +40,31 @@ const DomainListEditor = ({
   isPending = false,
 }: DomainListEditorProps) => {
   const [inputValue, setInputValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
   const config = variantConfig[variant];
   const Icon = config.icon;
 
   const handleAdd = () => {
-    const trimmed = inputValue.trim().toLowerCase();
-    if (trimmed && !domains.includes(trimmed)) {
-      onAdd(trimmed);
-      setInputValue("");
+    const result = validateDomain(inputValue);
+
+    if (!result.success) {
+      setError(result.error);
+      return;
     }
+
+    if (domains.includes(result.data)) {
+      toast.error("이미 추가된 도메인입니다");
+      return;
+    }
+
+    onAdd(result.data);
+    setInputValue("");
+    setError(null);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+    if (error) setError(null);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -72,7 +90,7 @@ const DomainListEditor = ({
             key={domain}
             className="flex items-center justify-between rounded-md border bg-background px-3 py-2"
           >
-            <span className="text-sm">{domain}</span>
+            <span className="min-w-0 break-all text-sm">{domain}</span>
             <Button
               variant="ghost"
               size="icon-sm"
@@ -87,19 +105,27 @@ const DomainListEditor = ({
       </div>
 
       {/* Add Domain Input */}
-      <div className="flex gap-2">
-        <Input
-          placeholder="도메인 입력 (예: example.com)"
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          onKeyDown={handleKeyDown}
-          disabled={isPending}
-          className="flex-1"
-        />
-        <Button onClick={handleAdd} disabled={isPending || !inputValue.trim()} className="gap-1.5">
-          <Plus className="size-4" />
-          추가
-        </Button>
+      <div className="flex flex-col gap-1.5">
+        <div className="flex gap-2">
+          <Input
+            placeholder="도메인 입력 (예: example.com)"
+            value={inputValue}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            disabled={isPending}
+            className={cn("flex-1", error && "border-destructive")}
+            aria-invalid={!!error}
+          />
+          <Button
+            onClick={handleAdd}
+            disabled={isPending || !inputValue.trim()}
+            className="gap-1.5"
+          >
+            <Plus className="size-4" />
+            추가
+          </Button>
+        </div>
+        {error && <p className="text-sm text-destructive">{error}</p>}
       </div>
     </Card>
   );

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Input = ({ className, type, ...props }: React.ComponentProps<"input">) => {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+export { Input };

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,37 @@
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      // TODO: ThemeProvider 설정 후 next-themes의 useTheme()으로 교체
+      // 현재 프로젝트에 ThemeProvider가 없어서 light 고정
+      theme="light"
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/src/hooks/mutations/useSettingsMutations.ts
+++ b/src/hooks/mutations/useSettingsMutations.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  addBlacklistDomain,
+  addWhitelistDomain,
+  removeBlacklistDomain,
+  removeWhitelistDomain,
+} from "@/api/settingsApi";
+import { settingsQueries } from "@/queries/settingsQueries";
+
+export const useAddWhitelistMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: addWhitelistDomain,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: settingsQueries.all(),
+      });
+    },
+  });
+};
+
+export const useRemoveWhitelistMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: removeWhitelistDomain,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: settingsQueries.all(),
+      });
+    },
+  });
+};
+
+export const useAddBlacklistMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: addBlacklistDomain,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: settingsQueries.all(),
+      });
+    },
+  });
+};
+
+export const useRemoveBlacklistMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: removeBlacklistDomain,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: settingsQueries.all(),
+      });
+    },
+  });
+};

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,7 +1,60 @@
+import { useQuery } from "@tanstack/react-query";
+
+import DomainListEditor from "@/components/Settings/DomainListEditor";
+import {
+  useAddBlacklistMutation,
+  useAddWhitelistMutation,
+  useRemoveBlacklistMutation,
+  useRemoveWhitelistMutation,
+} from "@/hooks/mutations/useSettingsMutations";
+import { settingsQueries } from "@/queries/settingsQueries";
+
 export const SettingsPage = () => {
+  const { data: settings, isPending } = useQuery(settingsQueries.detail());
+
+  const addWhitelist = useAddWhitelistMutation();
+  const removeWhitelist = useRemoveWhitelistMutation();
+  const addBlacklist = useAddBlacklistMutation();
+  const removeBlacklist = useRemoveBlacklistMutation();
+
+  if (isPending) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p className="text-muted-foreground">설정을 불러오는 중...</p>
+      </div>
+    );
+  }
+
   return (
-    <div>
-      <h1>Settings Page</h1>
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      {/* Page Header */}
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold">설정</h1>
+        <p className="mt-1 text-muted-foreground">팩트체크 검증에 사용할 출처를 관리합니다.</p>
+      </div>
+
+      {/* Domain List Sections */}
+      <div className="flex flex-col gap-6">
+        <DomainListEditor
+          title="신뢰할 수 있는 사이트"
+          description="이 목록의 사이트는 팩트체크 검증 시 신뢰할 수 있는 출처로 우선 사용됩니다."
+          variant="whitelist"
+          domains={settings?.whitelist ?? []}
+          onAdd={(domain) => addWhitelist.mutate(domain)}
+          onRemove={(domain) => removeWhitelist.mutate(domain)}
+          isPending={addWhitelist.isPending || removeWhitelist.isPending}
+        />
+
+        <DomainListEditor
+          title="제외할 사이트"
+          description="이 목록의 사이트는 팩트체크 검증 시 출처로 사용되지 않습니다."
+          variant="blacklist"
+          domains={settings?.blacklist ?? []}
+          onAdd={(domain) => addBlacklist.mutate(domain)}
+          onRemove={(domain) => removeBlacklist.mutate(domain)}
+          isPending={addBlacklist.isPending || removeBlacklist.isPending}
+        />
+      </div>
     </div>
   );
 };

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import DomainListEditor from "@/components/Settings/DomainListEditor";
+import { Button } from "@/components/ui/button";
 import {
   useAddBlacklistMutation,
   useAddWhitelistMutation,
@@ -10,17 +12,56 @@ import {
 import { settingsQueries } from "@/queries/settingsQueries";
 
 export const SettingsPage = () => {
-  const { data: settings, isPending } = useQuery(settingsQueries.detail());
+  const { data: settings, isPending, isError, refetch } = useQuery(settingsQueries.detail());
 
   const addWhitelist = useAddWhitelistMutation();
   const removeWhitelist = useRemoveWhitelistMutation();
   const addBlacklist = useAddBlacklistMutation();
   const removeBlacklist = useRemoveBlacklistMutation();
 
+  const handleAddWhitelist = (domain: string) => {
+    addWhitelist.mutate(domain, {
+      onSuccess: () => toast.success("신뢰할 수 있는 사이트에 추가되었습니다"),
+      onError: () => toast.error("도메인 추가에 실패했습니다"),
+    });
+  };
+
+  const handleRemoveWhitelist = (domain: string) => {
+    removeWhitelist.mutate(domain, {
+      onSuccess: () => toast.success("신뢰할 수 있는 사이트에서 삭제되었습니다"),
+      onError: () => toast.error("도메인 삭제에 실패했습니다"),
+    });
+  };
+
+  const handleAddBlacklist = (domain: string) => {
+    addBlacklist.mutate(domain, {
+      onSuccess: () => toast.success("제외할 사이트에 추가되었습니다"),
+      onError: () => toast.error("도메인 추가에 실패했습니다"),
+    });
+  };
+
+  const handleRemoveBlacklist = (domain: string) => {
+    removeBlacklist.mutate(domain, {
+      onSuccess: () => toast.success("제외할 사이트에서 삭제되었습니다"),
+      onError: () => toast.error("도메인 삭제에 실패했습니다"),
+    });
+  };
+
   if (isPending) {
     return (
       <div className="flex flex-1 items-center justify-center">
         <p className="text-muted-foreground">설정을 불러오는 중...</p>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4">
+        <p className="text-muted-foreground">설정을 불러올 수 없습니다.</p>
+        <Button variant="outline" onClick={() => void refetch()}>
+          다시 시도
+        </Button>
       </div>
     );
   }
@@ -40,8 +81,8 @@ export const SettingsPage = () => {
           description="이 목록의 사이트는 팩트체크 검증 시 신뢰할 수 있는 출처로 우선 사용됩니다."
           variant="whitelist"
           domains={settings?.whitelist ?? []}
-          onAdd={(domain) => addWhitelist.mutate(domain)}
-          onRemove={(domain) => removeWhitelist.mutate(domain)}
+          onAdd={handleAddWhitelist}
+          onRemove={handleRemoveWhitelist}
           isPending={addWhitelist.isPending || removeWhitelist.isPending}
         />
 
@@ -50,8 +91,8 @@ export const SettingsPage = () => {
           description="이 목록의 사이트는 팩트체크 검증 시 출처로 사용되지 않습니다."
           variant="blacklist"
           domains={settings?.blacklist ?? []}
-          onAdd={(domain) => addBlacklist.mutate(domain)}
-          onRemove={(domain) => removeBlacklist.mutate(domain)}
+          onAdd={handleAddBlacklist}
+          onRemove={handleRemoveBlacklist}
           isPending={addBlacklist.isPending || removeBlacklist.isPending}
         />
       </div>

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import { Toaster } from "@/components/ui/sonner";
+
 import { QueryProvider } from "./QueryProvider";
 
 interface AppProvidersProps {
@@ -7,5 +9,10 @@ interface AppProvidersProps {
 }
 
 export const AppProviders = ({ children }: AppProvidersProps) => {
-  return <QueryProvider>{children}</QueryProvider>;
+  return (
+    <QueryProvider>
+      {children}
+      <Toaster />
+    </QueryProvider>
+  );
 };

--- a/src/queries/settingsQueries.ts
+++ b/src/queries/settingsQueries.ts
@@ -1,0 +1,13 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { getSettings } from "@/api/settingsApi";
+
+export const settingsQueries = {
+  all: () => ["settings"] as const,
+
+  detail: () =>
+    queryOptions({
+      queryKey: [...settingsQueries.all(), "detail"],
+      queryFn: getSettings,
+    }),
+};

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,4 @@
+export interface SettingsResponse {
+  whitelist: string[];
+  blacklist: string[];
+}

--- a/src/utils/validateDomain.ts
+++ b/src/utils/validateDomain.ts
@@ -1,0 +1,26 @@
+const DOMAIN_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/;
+const MAX_DOMAIN_LENGTH = 253;
+
+export const validateDomain = (
+  value: string,
+): { success: true; data: string } | { success: false; error: string } => {
+  if (!value || typeof value !== "string") {
+    return { success: false, error: "도메인을 입력하세요" };
+  }
+
+  const trimmed = value.trim().toLowerCase();
+
+  if (!trimmed) {
+    return { success: false, error: "도메인을 입력하세요" };
+  }
+
+  if (trimmed.length > MAX_DOMAIN_LENGTH) {
+    return { success: false, error: `도메인은 ${MAX_DOMAIN_LENGTH}자를 초과할 수 없습니다` };
+  }
+
+  if (!DOMAIN_REGEX.test(trimmed)) {
+    return { success: false, error: "올바른 도메인 형식이 아닙니다 (예: example.com)" };
+  }
+
+  return { success: true, data: trimmed };
+};


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)
- Closes #20

## 🛠️ 작업 내용 (Description)
- AS-IS: 설정 페이지가 플레이스홀더 상태
- TO-BE: 화이트리스트/블랙리스트 도메인 관리 UI 구현

### 주요 변경사항
1. **shadcn/ui Input 컴포넌트 추가**
2. **설정 페이지 API 및 Query 레이어 구현**
   - `settingsApi.ts`: CRUD API 함수
   - `settingsQueries.ts`: TanStack Query v5 `queryOptions` 패턴
   - `useSettingsMutations.ts`: Mutation Hooks
3. **설정 페이지 UI 구현**
   - `DomainListEditor.tsx`: 재사용 가능한 도메인 리스트 편집 컴포넌트 (IoC 패턴)
   - `SettingsPage.tsx`: 화이트리스트/블랙리스트 섹션
4. **Sonner Toast 컴포넌트 추가**
5. **도메인 유효성 검사 및 에러 처리**
   - `validateDomain.ts`: 정규식 기반 도메인 검증 (최대 253자)
   - Query 에러 시 재시도 UI
   - Mutation 성공/실패 toast 알림

## 📸 스크린샷 (Screenshots - Optional)
| 화면 | 상호작용 |
| :---: | :---: |
| <img width="400" height="800" alt="스크린샷 2026-01-13 오후 10 10 05" src="https://github.com/user-attachments/assets/d68ecd4c-229e-4379-b04c-3c67cb3187d4" /> |  <img width="600" height="800" alt="스크린샷 2026-01-13 오후 10 11 27" src="https://github.com/user-attachments/assets/aaf93d16-d076-4bd6-989b-f8d81fef71d5" />|

## ✅ 체크리스트 (Self Checklist)

**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요?
- [ ] (필요 시) 관련 문서나 API 명세서를 업데이트했나요?

**UI / UX (해당 시)**
- [x] 다양한 화면 크기(모바일/데스크탑)에서 깨짐이 없나요?
- [ ] 주요 브라우저에서 동작을 확인했나요?

**안정성 및 배포**
- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요?
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 🧪 테스트 방법 (How to Test)
1. `http://localhost:5173/settings` 접속
2. 화이트리스트/블랙리스트 섹션 확인
3. 도메인 추가/삭제 테스트
4. 잘못된 형식 입력 시 에러 메시지 확인

## ⚠️ 특이사항 (Notes)
- Sonner Toast에서 `next-themes` 의존성 제거 (ThemeProvider 미설정으로 light 고정)
- Tailwind CSS v4 괄호 문법으로 디자인 토큰 참조 (`text-(--verdict-true)`)
- Zod 미설치로 단순 함수 기반 유효성 검사 사용
