### PR TITLE
fix: 프로덕션 세션 초기화 오류 수정

### DIFF
--- a/src/hooks/queries/useSessionQuery.ts
+++ b/src/hooks/queries/useSessionQuery.ts
@@ -18,7 +18,7 @@ export const useSessionQuery = () => {
     queryFn: async () => {
       if (isGuest) {
         await refreshGuestToken();
-        return;
+        return null;
       }
 
       try {
@@ -30,10 +30,12 @@ export const useSessionQuery = () => {
           (error.response?.status === 401 || error.response?.status === 403)
         ) {
           await refreshGuestToken();
-          return;
+          return null;
         }
         throw error;
       }
+
+      return null;
     },
     enabled: !accessToken,
     retry: true,


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)
- Fixes #37 

## 🛠️ 작업 내용 (Description)
- AS-IS:
    -  useSessionQuery의 queryFn이 undefined를 반환하여 TanStack Query v5에서 에러로 처리됨
- TO-BE:
    -  모든 분기에서 null을 반환하도록 수정

## ✅ 체크리스트 (Self Checklist)

**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요?

**안정성 및 배포**
- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요?
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 🧪 테스트 방법 (How to Test)
1. Vercel 배포 후 배포 사이트(ex. https://rtfact.site) 접속
2. 게스트 세션이 정상 생성되어 메인 페이지가 표시되는지 확인

## ⚠️ 특이사항 (Notes)
- TanStack Query v5에서 queryFn이 undefined를 반환하면 내부적으로 throw new Error 처리됨
- 개발 환경에서는 console.error로 경고만 출력되어 발견이 어려웠음
- 프로덕션에서는 console.error 없이 조용히 에러 발생